### PR TITLE
Add build verification for hub and leaf configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "**" ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Build Dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "**" ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Bahamut CI Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+name: Bahamut CI Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie-slim
+
+    strategy:
+      matrix:
+        role: [hub, leaf]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Build Dependencies
+        run: |
+          apt-get update
+          apt-get install -y build-essential libssl-dev libc6-dev zlib1g-dev file
+
+      - name: Configure and Patch
+        run: |
+          ./configure
+          
+          # Patching the config header in the include directory
+          CONFIG_H="include/config.h"
+          
+          if [ "${{ matrix.role }}" = "hub" ]; then
+            echo "Building as HUB..."
+            sed -i 's/#undef HUB/#define HUB/g' "$CONFIG_H"
+          else
+            echo "Building as LEAF..."
+          fi
+          
+          echo "Enabling SSL..."
+          sed -i 's/#undef USE_SSL/#define USE_SSL/g' "$CONFIG_H"
+
+      - name: Compile and Install
+        run: |
+          make -j$(nproc)
+          make install
+
+      - name: Verify ircd ELF
+        run: |
+          TARGET="./src/ircd" 
+          
+          if [ -f "$TARGET" ] && file "$TARGET" | grep -q "ELF"; then
+            echo "Success: ${{ matrix.role }} 'ircd' is a valid ELF."
+          else
+            echo "Error: 'ircd' binary not found in src/ or is invalid."
+            ls -R
+            exit 1
+          fi


### PR DESCRIPTION
Adds a GitHub Action to automate build testing for Bahamut.

### Key Changes:
- Matrix Build: Runs parallel tests for both hub and leaf roles.
- Environment: Uses a debian:trixie-slim container for consistent dependencies.
- Configuration: Automatically patches include/config.h to enable SSL and set the server role.
- Verification: Confirms the ircd binary compiles and links correctly as a valid ELF file.

This ensures that changes don't break compilation for either server type before merging.