### PR TITLE
Fix DNS resolution on 64-bit and add ircop debug messages

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1198,10 +1198,6 @@
  */
 #define WEBIRC
 
-/* Disable WEBIRC support if we're running on INET6 */
-#if defined(INET6) && defined(WEBIRC)
-#undef WEBIRC
-#endif
 
 /* IPV6_BIND_V6_ONLY
  * Define this if you want your ipv6 server to bind only ipv6 addresses

--- a/src/res.c
+++ b/src/res.c
@@ -568,11 +568,12 @@ static void resend_query(ResRQ * rptr)
 	break;
     case T_A:
 	(void) do_query_name(NULL, rptr->name, rptr, T_A);
+	break;
 #ifdef INET6
     case T_AAAA:
 	(void) do_query_name(NULL, rptr->name, rptr, T_AAAA);
-#endif
 	break;
+#endif
     default:
 	break;
     }

--- a/src/res.c
+++ b/src/res.c
@@ -893,7 +893,7 @@ static int proc_answer(ResRQ * rptr, HEADER *hptr, char *buf, char *eob)
 	cp += sizeof(short);
 	
 	rptr->ttl = _getlong(cp);
-	cp += sizeof(rptr->ttl);
+	cp += 4; /* DNS wire TTL is always 32-bit, not sizeof(time_t) */
 	dlen = (int) _getshort(cp);
 	cp += sizeof(short);
 	

--- a/src/res.c
+++ b/src/res.c
@@ -1847,7 +1847,7 @@ find_cache_number(ResRQ * rptr, char *numb)
 #else
 	    if(!memcmp(((struct IN_ADDR *)cp->he.h_addr_list[i])->S_ADDR,
 				    ((struct IN_ADDR *)ip)->S_ADDR,
-				    sizeof(struct IN_ADDR)));
+				    sizeof(struct IN_ADDR)))
 #endif
 	    {
 		cainfo.ca_nu_hits++;

--- a/src/res.c
+++ b/src/res.c
@@ -346,6 +346,10 @@ static int send_res_msg(char *msg, int len, int rcount)
     for (i = 0; i < max; i++)
     {
 	_res.nsaddr_list[i].sin_family = AF_INET;
+	sendto_ops_lev(DEBUG_LEV, "DNS sendto: server=%s:%d fd=%d len=%d",
+		       inet_ntoa(_res.nsaddr_list[i].sin_addr),
+		       ntohs(_res.nsaddr_list[i].sin_port),
+		       resfd, len);
 	if (sendto(resfd, msg, len, 0,
 		   (struct sockaddr *) &(_res.nsaddr_list[i]),
 		   sizeof(struct sockaddr)) == len)
@@ -545,6 +549,17 @@ static int query_name(char *name, int class, int type, ResRQ * rptr)
     } while (find_id(ntohs(hptr->id)));
     rptr->id = ntohs(hptr->id);
     rptr->sends++;
+    {
+	char hexbuf[MAXPACKET * 3 + 1];
+	int i;
+	for (i = 0; i < r && i * 3 < sizeof(hexbuf) - 3; i++)
+	    ircsprintf(hexbuf + i * 3, "%02x ", (unsigned char)buf[i]);
+	hexbuf[i * 3] = '\0';
+	sendto_ops_lev(DEBUG_LEV, "DNS UDP query: type=%s(%d) name=%s (%d bytes) hex=[%s]",
+		       type == T_PTR ? "PTR" : type == T_AAAA ? "AAAA" :
+		       type == T_A ? "A" : "?",
+		       type, name, r, hexbuf);
+    }
     s = send_res_msg(buf, r, rptr->sends);
     if (s == -1)
     {
@@ -1046,23 +1061,26 @@ static int proc_answer(ResRQ * rptr, HEADER *hptr, char *buf, char *eob)
 				   "DNS_PTR from an acceptable (%s)", acc);
 #endif
 	    
-	    if ((n = dn_expand(buf, eob, cp, hostbuf, HOSTLEN - 1)) < 0) 
+	    if ((n = dn_expand(buf, eob, cp, hostbuf, HOSTLEN - 1)) < 0)
 	    {
 		cp = NULL;
 		break;
 	    }
-	    
+
 	    /*
 	     * This comment is based on analysis by Shadowfax,
 	     * Jolo and johan, not me. (Dianora) I am only
 	     * commenting it.
-	     * 
+	     *
 	     * dn_expand is guaranteed to not return more than
 	     * sizeof(hostbuf) but do all implementations of
 	     * dn_expand also guarantee buffer is terminated with
 	     * null byte? Lets not take chances. -Dianora
 	     */
 	    hostbuf[HOSTLEN] = '\0';
+	    sendto_ops_lev(DEBUG_LEV,
+			   "DNS PTR RDATA dn_expand: n=%d hostbuf=%s (HOSTLEN=%d)",
+			   n, hostbuf, HOSTLEN);
 	    cp += n;
 	    len = strlen(hostbuf);
 	    
@@ -1227,7 +1245,19 @@ struct hostent *get_res(char *lp)
     rc = recvfrom(resfd, buf, sizeof(buf), 0, (struct sockaddr *) &sin, &len);
     if (rc <= sizeof(HEADER))
 	return getres_err(rptr, lp);
-    
+
+    {
+	unsigned char *raw = (unsigned char *)buf;
+	char hexbuf[MAXPACKET * 3 + 1];
+	int i;
+	for (i = 0; i < rc && i * 3 < sizeof(hexbuf) - 3; i++)
+	    ircsprintf(hexbuf + i * 3, "%02x ", raw[i]);
+	hexbuf[i * 3] = '\0';
+	sendto_ops_lev(DEBUG_LEV,
+		       "DNS UDP raw reply (%d bytes): [%s]",
+		       rc, hexbuf);
+    }
+
     /*
      * convert DNS reply reader from Network byte order to CPU byte
      * order.
@@ -1248,8 +1278,11 @@ struct hostent *get_res(char *lp)
      * just ignore this response.
      */
     rptr = find_id(hptr->id);
-    if (!rptr)
+    if (!rptr) {
+	sendto_ops_lev(DEBUG_LEV, "DNS orphaned reply: id=%d rcode=%d ancount=%d",
+		       hptr->id, hptr->rcode, hptr->ancount);
 	return getres_err(rptr, lp);
+    }
     /*
      * check against possibly fake replies
      */
@@ -1272,6 +1305,20 @@ struct hostent *get_res(char *lp)
 
     if ((hptr->rcode != NOERROR) || (hptr->ancount == 0))
     {
+	sendto_ops_lev(DEBUG_LEV,
+		       "DNS UDP reply: rcode=%d(%s) ancount=%d nscount=%d arcount=%d tc=%d type=%s(%d) name=%s",
+		       hptr->rcode,
+		       hptr->rcode == NXDOMAIN ? "NXDOMAIN" :
+		       hptr->rcode == SERVFAIL ? "SERVFAIL" :
+		       hptr->rcode == FORMERR ? "FORMERR" :
+		       hptr->rcode == REFUSED ? "REFUSED" :
+		       hptr->rcode == NOERROR ? "NOERROR" : "?",
+		       hptr->ancount, hptr->nscount, hptr->arcount, hptr->tc,
+		       rptr->type == T_PTR ? "PTR" :
+		       rptr->type == T_AAAA ? "AAAA" :
+		       rptr->type == T_A ? "A" : "?",
+		       rptr->type,
+		       rptr->name ? rptr->name : inet_ntop(AFINET, &rptr->addr, mydummy, sizeof(mydummy)));
 	switch (hptr->rcode)
 	{
 	case NXDOMAIN:
@@ -1304,8 +1351,17 @@ struct hostent *get_res(char *lp)
 	}
 	return getres_err(rptr, lp);
     }
+    sendto_ops_lev(DEBUG_LEV,
+		   "DNS UDP reply OK: ancount=%d tc=%d type=%s(%d) name=%s (%d bytes)",
+		   hptr->ancount, hptr->tc,
+		   rptr->type == T_PTR ? "PTR" :
+		   rptr->type == T_AAAA ? "AAAA" :
+		   rptr->type == T_A ? "A" : "?",
+		   rptr->type,
+		   rptr->name ? rptr->name : inet_ntop(AFINET, &rptr->addr, mydummy, sizeof(mydummy)),
+		   rc);
     a = proc_answer(rptr, hptr, buf, buf + rc);
-    
+
 #ifdef DEBUG
     Debug((DEBUG_INFO, "get_res:Proc answer = %d", a));
 #endif
@@ -1354,12 +1410,21 @@ struct hostent *get_res(char *lp)
 	else
 		type = T_AAAA;
 #endif
+	sendto_ops_lev(DEBUG_LEV,
+		       "DNS forward verify: %s -> %s(%d) (v4mapped=%d)",
+		       rptr->he.h_name,
+		       type == T_AAAA ? "AAAA" : "A", type,
+		       IN6_IS_ADDR_V4MAPPED(&rptr->he.h_addr));
 	if ((hp2 = gethost_byname_type(rptr->he.h_name, &rptr->cinfo, type)))
 	    if (lp)
 		memcpy(lp, (char *) &rptr->cinfo, sizeof(Link));
-	
+
 	if(!hp2)
 	{
+	    sendto_ops_lev(DEBUG_LEV,
+			   "DNS forward verify FAILED: %s has no %s record, falling back to reverse-only",
+			   rptr->he.h_name,
+			   type == T_AAAA ? "AAAA" : "A");
 	    memcpy(&last->he_rev, &rptr->he, sizeof(struct hent));
 	    memset(&rptr->he, 0, sizeof(struct hent));
 	    last->has_rev = 1;


### PR DESCRIPTION
## Summary

DNS resolution has been completely broken on 64-bit builds. Clients show raw IP addresses instead of resolved hostnames, DNS cache stays empty, and errors pile up. This PR fixes three bugs in the resolver and adds +d debug instrumentation for diagnosing DNS issues.

## The bugs

### 1. 64-bit TTL parsing breaks all DNS answers (`proc_answer`)

The critical one. `cp += sizeof(rptr->ttl)` advances by `sizeof(time_t)` = **8 bytes** on 64-bit, but the DNS wire format TTL is always **4 bytes**. The pointer overshoots by 4 bytes into the RDATA, causing:

- `dlen` to be read from garbage
- `dn_expand` to start mid-RDATA, silently stripping the first label from PTR answers (e.g. `m42.openssl.it` → `openssl.it`)
- Forward verification to query the wrong hostname, which fails, so no cache entry is ever created

This bug affects every DNS answer parsed on any 64-bit architecture (amd64, aarch64).

**Fix:** `cp += 4`

### 2. Stray semicolon in `find_cache_number` INET6 path

```c
if(!memcmp(...));  // ← stray semicolon makes the if a no-op
```

The `memcmp` result is discarded, so INET6 cache lookups by address never match.

### 3. Missing `break` in `resend_query` T_A case

Falls through from `T_A` into `default`, hitting `resend = 0` and killing legitimate A query retries on INET6 builds.

## Other changes

- **DNS debug messages for +d ircops**: query/reply logging with type names, rcode names, hex dumps, forward verification tracing, and DNS server address. Always compiled, only visible to +d opers.
- **Enable WEBIRC on INET6 builds**: removes the `#ifndef INET6` guard around `WEBIRC` in config.h.

## Test plan

- [ ] Build on 64-bit (amd64 or aarch64) with `--enable-inet6`
- [ ] Connect an IPv6 client and verify hostname shows instead of raw IP
- [ ] Verify `/stats dns` shows cache entries being created
- [ ] Check +d oper messages show the full PTR → forward verify → cache flow
- [ ] Connect an IPv4 client (v4-mapped `::ffff:x.x.x.x`) and verify hostname resolution