### PR TITLE
ci: GitHub Actions build workflow + Dockerfile hang fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,67 @@
+name: build
+
+on:
+  push:
+    branches: [master, develop, 'features/**', 'feat/**', 'ci/**', 'bugfix/**']
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  build:
+    name: build (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    container: debian:trixie
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [leaf, hub]
+
+    steps:
+      - name: install build deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            autoconf \
+            build-essential \
+            libssl-dev \
+            zlib1g-dev \
+            libcrypt-dev \
+            ca-certificates \
+            git
+
+      - uses: actions/checkout@v4
+
+      - name: seed options.h (${{ matrix.profile }})
+        run: cp buildbot/options.h_${{ matrix.profile }} include/options.h
+
+      - name: autoconf
+        run: autoconf
+
+      - name: configure
+        run: ./configure
+
+      - name: build
+        run: make
+
+      - name: verify binary
+        run: |
+          test -x ./src/ircd
+          ls -la ./src/ircd
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ircd-${{ matrix.profile }}
+          path: src/ircd
+          retention-days: 7
+
+  docker:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build image
+        run: docker build -t azzurra-bahamut:ci .
+      - name: smoke-check binary inside image
+        run: |
+          docker run --rm --entrypoint sh azzurra-bahamut:ci \
+            -c 'test -x /build/src/ircd'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,24 @@
 FROM debian:trixie
 
-# Enable i386 architecture for 32-bit build support
-RUN dpkg --add-architecture i386
-
-RUN apt-get update && apt-get install -y \
-    autoconf \
-    build-essential \
-    gcc-multilib \
-    libc6-dev:i386 \
-    zlib1g-dev:i386 \
-    libssl-dev:i386 \
-    libcrypt-dev:i386 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libcrypt-dev \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
 COPY . .
 
-# Regenerate configure from configure.in (in case it's stale)
+# Seed options.h with the leaf profile so configure does not invoke the
+# interactive ./config script (which would hang with no stdin).
+RUN cp buildbot/options.h_leaf include/options.h
+
+# Regenerate configure from configure.in (in case it's stale).
 RUN autoconf
 
-# Configure for 32-bit: pass CFLAGS/LDFLAGS so configure's own test
-# programs are also compiled as 32-bit, matching the final binary.
-RUN CFLAGS="-m32" LDFLAGS="-m32" ./configure
+RUN ./configure
 
 RUN make


### PR DESCRIPTION
## Summary
- New `.github/workflows/build.yml` — matrix build of both leaf and hub profiles under `debian:trixie`, plus a separate docker-build job that smoke-tests the image
- Fix `Dockerfile`: pre-seed `include/options.h` from `buildbot/options.h_leaf` before `autoconf`, otherwise `./configure` falls through to the interactive `./config` script and hangs with no stdin
- Drop the legacy `i386`/`gcc-multilib`/`:i386` apt set from `Dockerfile`.  Since `c9ded13` (Removed -m32, ircd works in 64bit mode) the ircd compiles cleanly as a native 64-bit binary — the multilib setup was dead weight and also happened to mask the configure-hang bug
- Workflow triggers: push to `master`/`develop`/`ci/**`/`feat/**`/`features/**`/`bugfix/**`; PR to `master`/`develop`
- Uploads `src/ircd` as a build artifact (7-day retention) for both profiles

## Test plan
- [x] Both matrix builds green on the fork: https://github.com/vjt/bahamut-azzurra/actions/runs/24680257225
- [x] `docker build` + `test -x /build/src/ircd` passes in the docker job
- [ ] Reviewer runtime-check one of the uploaded artifacts on a target host