### PR TITLE
m_list: frame ERR_RESTRICTED with RPL_LISTSTART/LISTEND (fix #10)

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -3189,8 +3189,22 @@ int m_list(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	return 0;
     }
 
-    if (check_restricted_user(sptr))
+    /*
+     * Issue #10: frame ERR_RESTRICTED with RPL_LISTSTART/LISTEND so that
+     * mIRC (and other clients gating on the list start/end numerics)
+     * don't hang waiting for list data. Inline the check here rather
+     * than calling check_restricted_user() — that helper would emit
+     * ERR_RESTRICTED before we get control back to interleave it.
+     */
+    if (restriction_enabled && MyClient(sptr) && !IsKnownNick(sptr) &&
+	(sptr->confs->value.aconf->flags & CONF_FLAGS_I_RESTRICTED) &&
+	!IsAnOper(sptr))
+    {
+	sendto_one(sptr, rpl_str(RPL_LISTSTART), me.name, parv[0]);
+	sendto_one(sptr, rpl_str(RPL_LISTEND), me.name, parv[0]);
+	sendto_one(sptr, err_str(ERR_RESTRICTED), me.name, sptr->name);
 	return 0;
+    }
 
     /* If a /list is in progress, then another one will cancel it */
     if ((lopt = sptr->user->lopt)!=NULL)


### PR DESCRIPTION
## Summary

Fixes #10.

Restricted users issuing `LIST` received a bare `ERR_RESTRICTED` (447)
with no `RPL_LISTSTART` (321) / `RPL_LISTEND` (323) bracket. mIRC (and
other clients that gate their list view on the start/end numerics)
hangs indefinitely waiting for `LISTEND`.

This PR inlines the restriction check in `m_list()` (`src/channel.c`)
with the LIST-specific numeric ordering suggested on the issue:

```
321 RPL_LISTSTART
323 RPL_LISTEND
447 ERR_RESTRICTED  (the notice that the user's connection is restricted)
```

`check_restricted_user()` (`src/s_misc.c:1211`) is left untouched —
its other callers (`m_userhost`, channel joins, channel messages,
umode changes) keep their current immediate-error behaviour.

## Out of scope (flagged for a follow-up)

The `!unknown_list_allowed && !IsKnownNick` branch a few lines above
in `m_list()` (`ERR_NOUNKNOWNLISTS`, numeric 446) has the same
missing-bracket hang. Deliberately left alone here to keep this PR
focused on #10; easy to extend in a second commit if desired.

## Test plan

Full plan with the automated Python harness + manual mIRC steps:
https://gist.github.com/vjt/ae0e65623da359472024eb0102c93c4b

TL;DR:

1. Testnet with `restriction_enabled = YES` + an `I:` line flagged
   `R` (`CONF_FLAGS_I_RESTRICTED`) matching the test client.
2. Connect *without* `/ns identify`, send `LIST`.
3. Assert captured numeric stream contains `321`, `323`, `447` in
   that order.

## Build

`make channel.o` clean on debian:trixie / gcc 13.2. No new warnings
(the pre-existing `check_for_spam inline declared but never defined`
is unrelated). The CI matrix from #21 will cover the full build.