### PR TITLE
fix: update proxy monitor URL to HTTPS + /kline/ path

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -277,7 +277,7 @@
 
 
 /* Services Definitions */
-#define STATS_NAME "services.azzurra.chat"
+#define STATS_NAME "stats.azzurra.chat"
 #define CHANSERV "ChanServ"
 #define NICKSERV "NickServ"
 #define MEMOSERV "MemoServ"
@@ -696,7 +696,7 @@
  * Rather self explanitory. If not specified in T: line,
  * we tell clients to go to "http://<this>"
  */
-#define DEFAULT_PROXY_INFO_URL "www.azzurra.chat"
+#define DEFAULT_PROXY_INFO_URL "www.azzurra.chat/kline/"
 
 /*
  * STAFF_ADDRESS

--- a/include/config.h
+++ b/include/config.h
@@ -277,7 +277,7 @@
 
 
 /* Services Definitions */
-#define STATS_NAME "stats.azzurra.chat"
+#define STATS_NAME "services.azzurra.chat"
 #define CHANSERV "ChanServ"
 #define NICKSERV "NickServ"
 #define MEMOSERV "MemoServ"

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -937,8 +937,8 @@ int main(int argc, char *argv[])
     }
 
 #ifdef WINGATE_NOTICE
-    strcpy(ProxyMonURL, "http://");
-    strncpyzt((ProxyMonURL + 7), DEFAULT_PROXY_INFO_URL, (TOPICLEN + 1) - 7);
+    strcpy(ProxyMonURL, "https://");
+    strncpyzt((ProxyMonURL + 8), DEFAULT_PROXY_INFO_URL, (TOPICLEN + 1) - 8);
     strncpyzt(ProxyMonHost, MONITOR_HOST, (HOSTLEN + 1));
 #endif
 

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1713,14 +1713,14 @@ initconf(int opt, int fd)
 	    else
 		strncpyzt(ProxyMonHost, aconf->host, sizeof(ProxyMonHost));
 	    
-	    strcpy(ProxyMonURL, "http://");
+	    strcpy(ProxyMonURL, "https://");
 
 	    if(!aconf->passwd || aconf->passwd[0] == '\0')
-		strncpyzt((ProxyMonURL + 7), DEFAULT_PROXY_INFO_URL,
-			  sizeof(ProxyMonURL) - 7);
+		strncpyzt((ProxyMonURL + 8), DEFAULT_PROXY_INFO_URL,
+			  sizeof(ProxyMonURL) - 8);
 	    else
-		strncpyzt((ProxyMonURL + 7), aconf->passwd,
-			  sizeof(ProxyMonURL) - 7);
+		strncpyzt((ProxyMonURL + 8), aconf->passwd,
+			  sizeof(ProxyMonURL) - 8);
 	    
 	    continue; /* no need to keep this as a conf entry.. */
 	} 


### PR DESCRIPTION
## Summary

- Update `DEFAULT_PROXY_INFO_URL` to include `/kline/` path suffix
- Switch `ProxyMonURL` prefix from `http://` to `https://` in both `ircd.c` and `s_conf.c`, with corrected offset (`+7` → `+8`) for the extra scheme character
- Update `STATS_NAME` from `services.azzurra.chat` to `stats.azzurra.chat`

## Test plan

- [x] Compiled and deployed on testnet (leaf6)
- [x] Verified proxy NOTICE shows `https://www.azzurra.chat/kline/` on clone detection
- [x] Full akill test: 6 v6 clones, 5 autokilled + 1 K-lined with correct reason URL