### PR TITLE
ircsprintf: fix integer-format buffer underflow that corrupts globals (REHASH SIGSEGV)

### DIFF
--- a/src/ircsprintf.c
+++ b/src/ircsprintf.c
@@ -1,6 +1,14 @@
 #include "ircsprintf.h"
 
-char num[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+/* Scratch buffer for the backward itoa/xtoa conversions below. Must hold
+ * the widest possible output: a 64-bit unsigned long is up to 20 decimal
+ * digits (or 16 hex), and the conversion writes digits backward from the
+ * end (see `s = &num[sizeof(num)-1]`). The old size of 12 underflowed for
+ * any value needing more than 11 digits — reachable via %lu/%ld, and also
+ * via %d/%i/%u when the arg was pulled with the wrong width (fixed below) —
+ * and clobbered adjacent globals. Keep the last byte as the NUL terminator
+ * the forward `while(*s)` read relies on. */
+char num[24] = { 0 };
 char itoa_tab[10] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'  };
 char xtoa_tab[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 
 		      'a', 'b', 'c', 'd', 'e', 'f'  };
@@ -39,9 +47,8 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 			buf[len++]=*s++;
 		    format++;
 		    break;
-		case 'u':
-		    format--; /* falls through and is caught below */
 		case 'l':
+		    /* long-width conversion: %l, %ld, %lu */
 		    if (*(format+1) == 'u')
 		    {
 			u=1;
@@ -54,17 +61,30 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    /* fallthrough */
+		    i=va_arg(ap, unsigned long);
+		    goto emit_dec;
+		case 'u':
+		    /* %u is an unsigned int, NOT a long. Reading it as an
+		     * unsigned long (as the old `case 'u': format--` route into
+		     * the %l path did) pulls the undefined upper 32 bits of the
+		     * argument slot on LP64 ABIs, yielding a huge value that
+		     * overflowed the itoa buffer above. Read the correct width. */
+		    u=1;
+		    i=va_arg(ap, unsigned int);
+		    goto emit_dec;
 		case 'd':
 		case 'i':
-		    i=va_arg(ap, unsigned long);
+		    /* %d/%i are int-width; same fix as %u. */
+		    u=0;
+		    i=va_arg(ap, unsigned int);
+		  emit_dec:
 		    if(!u)
 			if(i&0x80000000)
 			{
 			    buf[len++]='-'; /* it's negative.. */
 			    i = 0x80000000 - (i & ~0x80000000);
 			}
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=itoa_tab[i%10];
@@ -81,7 +101,7 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    i=va_arg(ap, long);
 		    buf[len++]='0';
 		    buf[len++]='x';
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=xtoa_tab[i%16];
@@ -130,9 +150,8 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 			buf[len++]=*s++;
 		    format++;
 		    break;
-		case 'u':
-		    format--; /* now fall through and it's caught, cool */
 		case 'l':
+		    /* long-width conversion: %l, %ld, %lu */
 		    if (*(format+1) == 'u')
 		    {
 			u=1;
@@ -145,17 +164,26 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    /* fallthrough */
+		    i=va_arg(ap, unsigned long);
+		    goto emit_dec_n;
+		case 'u':
+		    /* %u is int-width, not long — see the matching comment
+		     * in the size==0 branch above. */
+		    u=1;
+		    i=va_arg(ap, unsigned int);
+		    goto emit_dec_n;
 		case 'd':
 		case 'i':
-		    i=va_arg(ap, unsigned long);
+		    u=0;
+		    i=va_arg(ap, unsigned int);
+		  emit_dec_n:
 		    if(!u)
 			if(i&0x80000000)
 			{
 			    buf[len++]='-'; /* it's negative.. */
 			    i = 0x80000000 - (i & ~0x80000000);
 			}
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=itoa_tab[i%10];
@@ -173,9 +201,9 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    buf[len++]='0';
 		    if(len<size)
 			buf[len++]='x';
-		    else 
+		    else
 			break;
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=xtoa_tab[i%16];


### PR DESCRIPTION
## Summary

`irc_printf()` in `src/ircsprintf.c` has a buffer underflow in its integer
formatter that corrupts adjacent globals on LP64 builds. The most visible
symptom: an operator (or ADMINSERV) issuing **`REHASH` SIGSEGVs the server**.

## Root cause

The `%d`/`%i`/`%u` conversions pull their argument with
`va_arg(ap, unsigned long)` — a **64-bit** read for a **32-bit `int`**
argument. On LP64 ABIs (aarch64, x86-64) the upper 32 bits of the argument
slot are undefined, so the value gains garbage high bits. Concrete example
from `build_rplisupport()` formatting `TOPICLEN` (307):

```
i = 0x0000555500000133   (low 32 = 0x133 = 307, high 32 = 0x5555 garbage)
  = 93823560581427       (14 digits)
```

The itoa loop then writes those digits **backwards** from `&num[11]` into the
global `char num[12]` with **no lower bound**:

```c
s = &num[11];
do { *--s = itoa_tab[i%10]; i /= 10; } while (i != 0);
```

A value needing more than 11 digits underflows `num[]` and overwrites whatever
global precedes it. In practice that global is `KList1` (an empty
`aConfList {0, NULL}`): its `conf_list` pointer gets overwritten with ASCII
digits. The corruption is **latent** — `KList1` is empty so nothing iterates
it — until `REHASH`:

```
#0 free()                                     <- faults
#1 clear_conf_list (my_list=&KList1)   dich_conf.c:538  MyFree(my_list->conf_list)
#2 rehash ()                           s_conf.c:1113    clear_conf_list(&KList1)
#3 client_dopacket () ... main ()
```

`clear_conf_list(&KList1)` frees the corrupted `conf_list` pointer → SIGSEGV.

It is **optimization-sensitive**: only at `-O2` does `KList1` land in the
buffer's blast radius, so it reproduces on release builds but not `-O0`.
`%lu`/`%ld` can also legitimately produce up to 20 digits, which the 12-byte
buffer cannot hold either.

## Fix

1. Read `%d`/`%i`/`%u` with the correct **int** width (`va_arg(ap, unsigned int)`);
   keep `va_arg(ap, unsigned long)` only for the explicit `%l`/`%ld`/`%lu`
   paths. This removes the garbage high bits and also **corrects the ISUPPORT
   output** (`TOPICLEN` now prints `307`, not a 14-digit number).
2. Size the scratch buffer for the widest real output — a 64-bit `unsigned
   long` is up to 20 decimal / 16 hex digits — and start the backward write at
   `&num[sizeof(num)-1]` at all four conversion sites, so even a legitimately
   large `%lu` can no longer underflow.

Both the `size==0` and `size!=0` (snprintf) branches of `irc_printf()` are
patched.

## Validation

Built at `-O2 -g3` (release codegen + symbols):

- **Pre-fix**: a hardware watchpoint on `KList1.conf_list` fires during boot
  inside `irc_printf` (from `build_rplisupport`); an operator `REHASH` then
  faults in `free() <- clear_conf_list <- rehash`.
- **Post-fix**: the watchpoint never fires (KList1 stays `{0, NULL}`); an
  operator survives 10 consecutive `REHASH`es; and `RPL_ISUPPORT` reports the
  correct values (`MAXBANS=100 MAXCHANNELS=20 CHANNELLEN=32 TOPICLEN=307 …`).

Discovered while debugging a downstream bouncer's e2e testnet (a visitor
oper's `/rehash` crashed the leaf). No functional change to correct call
sites — only the argument width read and the scratch-buffer bound.