### PR TITLE
ircsprintf: test the sign at the argument's own width (Y2038 in the TS path)

### DIFF
--- a/src/ircsprintf.c
+++ b/src/ircsprintf.c
@@ -1,6 +1,14 @@
 #include "ircsprintf.h"
 
-char num[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+/* Scratch buffer for the backward itoa/xtoa conversions below. Must hold
+ * the widest possible output: a 64-bit unsigned long is up to 20 decimal
+ * digits (or 16 hex), and the conversion writes digits backward from the
+ * end (see `s = &num[sizeof(num)-1]`). The old size of 12 underflowed for
+ * any value needing more than 11 digits — reachable via %lu/%ld, and also
+ * via %d/%i/%u when the arg was pulled with the wrong width (fixed below) —
+ * and clobbered adjacent globals. Keep the last byte as the NUL terminator
+ * the forward `while(*s)` read relies on. */
+char num[24] = { 0 };
 char itoa_tab[10] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'  };
 char xtoa_tab[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 
 		      'a', 'b', 'c', 'd', 'e', 'f'  };
@@ -39,9 +47,8 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 			buf[len++]=*s++;
 		    format++;
 		    break;
-		case 'u':
-		    format--; /* falls through and is caught below */
 		case 'l':
+		    /* long-width conversion: %l, %ld, %lu */
 		    if (*(format+1) == 'u')
 		    {
 			u=1;
@@ -54,17 +61,30 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    /* fallthrough */
+		    i=va_arg(ap, unsigned long);
+		    goto emit_dec;
+		case 'u':
+		    /* %u is an unsigned int, NOT a long. Reading it as an
+		     * unsigned long (as the old `case 'u': format--` route into
+		     * the %l path did) pulls the undefined upper 32 bits of the
+		     * argument slot on LP64 ABIs, yielding a huge value that
+		     * overflowed the itoa buffer above. Read the correct width. */
+		    u=1;
+		    i=va_arg(ap, unsigned int);
+		    goto emit_dec;
 		case 'd':
 		case 'i':
-		    i=va_arg(ap, unsigned long);
+		    /* %d/%i are int-width; same fix as %u. */
+		    u=0;
+		    i=va_arg(ap, unsigned int);
+		  emit_dec:
 		    if(!u)
 			if(i&0x80000000)
 			{
 			    buf[len++]='-'; /* it's negative.. */
 			    i = 0x80000000 - (i & ~0x80000000);
 			}
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=itoa_tab[i%10];
@@ -81,7 +101,7 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    i=va_arg(ap, long);
 		    buf[len++]='0';
 		    buf[len++]='x';
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=xtoa_tab[i%16];
@@ -130,9 +150,8 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 			buf[len++]=*s++;
 		    format++;
 		    break;
-		case 'u':
-		    format--; /* now fall through and it's caught, cool */
 		case 'l':
+		    /* long-width conversion: %l, %ld, %lu */
 		    if (*(format+1) == 'u')
 		    {
 			u=1;
@@ -145,17 +164,26 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    /* fallthrough */
+		    i=va_arg(ap, unsigned long);
+		    goto emit_dec_n;
+		case 'u':
+		    /* %u is int-width, not long — see the matching comment
+		     * in the size==0 branch above. */
+		    u=1;
+		    i=va_arg(ap, unsigned int);
+		    goto emit_dec_n;
 		case 'd':
 		case 'i':
-		    i=va_arg(ap, unsigned long);
+		    u=0;
+		    i=va_arg(ap, unsigned int);
+		  emit_dec_n:
 		    if(!u)
 			if(i&0x80000000)
 			{
 			    buf[len++]='-'; /* it's negative.. */
 			    i = 0x80000000 - (i & ~0x80000000);
 			}
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=itoa_tab[i%10];
@@ -173,9 +201,9 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    buf[len++]='0';
 		    if(len<size)
 			buf[len++]='x';
-		    else 
+		    else
 			break;
-		    s=&num[11];
+		    s=&num[sizeof(num)-1];
 		    do
 		    {
 			*--s=xtoa_tab[i%16];

--- a/src/ircsprintf.c
+++ b/src/ircsprintf.c
@@ -61,7 +61,18 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    i=va_arg(ap, unsigned long);
+		    /* Pull the argument at the type it was passed as: reading a
+		     * `long` through va_arg(ap, unsigned long) is only defined
+		     * when the value is representable in both types (C99
+		     * 7.15.1.1p2), which a negative TS or LONG_MIN is not. It
+		     * happens to work wherever the two share representation and
+		     * argument slot, but that is the ABI being kind, not a
+		     * guarantee. Convert after the read instead, where the
+		     * conversion is well defined. */
+		    if (u)
+			i=va_arg(ap, unsigned long);
+		    else
+			i=(unsigned long)va_arg(ap, long);
 		    goto emit_dec;
 		case 'u':
 		    /* %u is an unsigned int, NOT a long. Reading it as an
@@ -174,7 +185,18 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    }
 		    else
 			u=0;
-		    i=va_arg(ap, unsigned long);
+		    /* Pull the argument at the type it was passed as: reading a
+		     * `long` through va_arg(ap, unsigned long) is only defined
+		     * when the value is representable in both types (C99
+		     * 7.15.1.1p2), which a negative TS or LONG_MIN is not. It
+		     * happens to work wherever the two share representation and
+		     * argument slot, but that is the ABI being kind, not a
+		     * guarantee. Convert after the read instead, where the
+		     * conversion is well defined. */
+		    if (u)
+			i=va_arg(ap, unsigned long);
+		    else
+			i=(unsigned long)va_arg(ap, long);
 		    goto emit_dec_n;
 		case 'u':
 		    /* %u is int-width, not long — see the matching comment

--- a/src/ircsprintf.c
+++ b/src/ircsprintf.c
@@ -74,15 +74,25 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		    goto emit_dec;
 		case 'd':
 		case 'i':
-		    /* %d/%i are int-width; same fix as %u. */
+		    /* %d/%i are int-width; same fix as %u. Sign-extend to
+		     * long width here so the test below needs to know
+		     * nothing about the width the argument came in at. */
 		    u=0;
-		    i=va_arg(ap, unsigned int);
+		    i=(unsigned long)(long)va_arg(ap, int);
 		  emit_dec:
+		    /* The sign lives in the top bit of `i`, which is a long:
+		     * bit 63 on LP64, not bit 31. The old `i & 0x80000000`
+		     * hardcoded bit 31, so a %ld/%li whose value merely had
+		     * bit 31 set printed as negative — and ts_val is a long
+		     * (include/struct.h), so from 2038-01-19 03:14:08 UTC
+		     * every timestamp on the wire (NICK/SJOIN bursts, TS
+		     * comparisons peers echo back) would have gone out with
+		     * an inverted sign. Test the whole width instead. */
 		    if(!u)
-			if(i&0x80000000)
+			if((long)i < 0)
 			{
 			    buf[len++]='-'; /* it's negative.. */
-			    i = 0x80000000 - (i & ~0x80000000);
+			    i = 0UL - i; /* magnitude; wraps LONG_MIN right */
 			}
 		    s=&num[sizeof(num)-1];
 		    do
@@ -175,13 +185,15 @@ inline int irc_printf(char *str, const char *pattern, va_list vl)
 		case 'd':
 		case 'i':
 		    u=0;
-		    i=va_arg(ap, unsigned int);
+		    i=(unsigned long)(long)va_arg(ap, int);
 		  emit_dec_n:
+		    /* Width-independent sign test — see the matching comment
+		     * in the size==0 branch above. */
 		    if(!u)
-			if(i&0x80000000)
+			if((long)i < 0)
 			{
 			    buf[len++]='-'; /* it's negative.. */
-			    i = 0x80000000 - (i & ~0x80000000);
+			    i = 0UL - i; /* magnitude; wraps LONG_MIN right */
 			}
 		    s=&num[sizeof(num)-1];
 		    do


### PR DESCRIPTION
**Stacked on #26** — the diff below includes #26's commit. Merge #26 first, or merge this and #26 is included. It is not independent: before #26, `%d/%i/%u` were pulled as `unsigned long`, and the 32-bit sign test was the only reason int-width negatives came out right. Rebased on `master` alone, this patch regresses them.

### The defect

The decimal conversion in `irc_printf()` decides the sign with

```c
if(i & 0x80000000)
```

`i` is an `unsigned long`. On LP64 that tests **bit 31 of a 64-bit value**, and the negation under it — `i = 0x80000000 - (i & ~0x80000000)` — is 32-bit arithmetic as well, so both the sign and the digits are wrong.

`ts_val` is a `long` (`include/struct.h`), and every timestamp on the wire is emitted with `%ld` — the NICK bursts in `s_user.c`, `s_serv.c`, `m_nick.c`. **From 2038-01-19 03:14:08 UTC a current TS has bit 31 set**, so it goes out with an inverted sign. Not a crash: a silently corrupt TS, which is exactly what nick-collision handling and channel TS comparison run on.

It is not only a 2038 problem — the same test mangles values reachable today: `LONG_MAX` prints as `-1`, `LONG_MIN` prints as a positive number.

### The fix

Sign-extend the int-width cases to long at the `va_arg`, then test the whole width with `(long)i < 0` and take the magnitude with unsigned arithmetic (which is also correct for `LONG_MIN`). Both halves of the function — the sprintf and the snprintf branch — get it.

### Measured, not deduced

Differential test against libc `snprintf`, aarch64 (Debian, gcc 12, `-O2`), driving the **real `src/ircsprintf.c`** from this tree, not a replica. Sign-relevant values of `%ld`, `%d`, `%i`, `%lu`, `%u`, plus a full s2s NICK line.

Before this commit (i.e. #26 alone) — **19/24**:

```
FAIL %ld  v=2147483648           libc=2147483648           got=-2147483648
FAIL %ld  v=2208988800           libc=2208988800           got=-2085978496
FAIL %ld  v=9223372036854775807  libc=9223372036854775807  got=-1
FAIL %ld  v=-9223372036854775808 libc=-9223372036854775808 got=9223372036854775808
FAIL s2s NICK
  libc=NICK someone 1 2147483648 user host server :real name
   got=NICK someone 1 -2147483648 user host server :real name
```

After — **24/24**. The `%d`/`%i`/`%lu`/`%u` cases are untouched by this patch and pass in both runs; `-1`, `INT_MIN`, `-2147483648L` included.

<details>
<summary>Test program (drop next to the tree, <code>gcc -O2 -fgnu89-inline -Iinclude -o t y2038_test.c src/ircsprintf.c</code>)</summary>

```c
/* Differential test: the REAL ircsprintf.c from the tree vs libc snprintf.
 * Compiled against src/ircsprintf.c, not a hand-written replica. */
#include <stdio.h>
#include <string.h>
#include <limits.h>
#include <stddef.h>

int ircsprintf(char *str, const char *format, ...);
int ircsnprintf(char *str, size_t size, const char *format, ...);

static int fail = 0, total = 0;

static void ckl(const char *fmt, long v)
{
    char got[128], want[128], gotn[128];
    total++;
    ircsprintf(got, fmt, v);
    ircsnprintf(gotn, sizeof(gotn), fmt, v);
    snprintf(want, sizeof(want), fmt, v);
    if (strcmp(got, want) || strcmp(gotn, want)) {
        fail++;
        printf("  FAIL %-6s v=%-22ld libc=%-22s sprintf=%-22s snprintf=%s\n",
               fmt, v, want, got, gotn);
    }
}

static void cki(const char *fmt, int v)
{
    char got[128], want[128], gotn[128];
    total++;
    ircsprintf(got, fmt, v);
    ircsnprintf(gotn, sizeof(gotn), fmt, v);
    snprintf(want, sizeof(want), fmt, v);
    if (strcmp(got, want) || strcmp(gotn, want)) {
        fail++;
        printf("  FAIL %-6s v=%-22d libc=%-22s sprintf=%-22s snprintf=%s\n",
               fmt, v, want, got, gotn);
    }
}

static void cku(const char *fmt, unsigned long v)
{
    char got[128], want[128], gotn[128];
    total++;
    ircsprintf(got, fmt, v);
    ircsnprintf(gotn, sizeof(gotn), fmt, v);
    snprintf(want, sizeof(want), fmt, v);
    if (strcmp(got, want) || strcmp(gotn, want)) {
        fail++;
        printf("  FAIL %-6s v=%-22lu libc=%-22s sprintf=%-22s snprintf=%s\n",
               fmt, v, want, got, gotn);
    }
}

int main(void)
{
    /* %ld — the TS path. ts_val is a long (include/struct.h). */
    ckl("%ld", 0L);
    ckl("%ld", 1L);
    ckl("%ld", -1L);
    ckl("%ld", 1785283000L);          /* a TS from today */
    ckl("%ld", 2147483647L);          /* 2038-01-19 03:14:07 — last ok second */
    ckl("%ld", 2147483648L);          /* 2038-01-19 03:14:08 — the cliff */
    ckl("%ld", 2208988800L);          /* year 2040 */
    ckl("%ld", 4294967296L);
    ckl("%ld", -2147483648L);
    ckl("%ld", LONG_MAX);
    ckl("%ld", LONG_MIN);

    /* %d/%i — must not regress. */
    cki("%d", 0);
    cki("%d", 1);
    cki("%d", -1);
    cki("%d", -5);
    cki("%d", INT_MAX);
    cki("%d", INT_MIN);
    cki("%i", -12345);

    /* unsigned paths — no sign handling at all. */
    cku("%lu", 0UL);
    cku("%lu", 4294967295UL);
    cku("%lu", 18446744073709551615UL);
    cku("%lu", 2147483648UL);

    {   /* %u is int-width */
        char got[128], want[128];
        total++;
        ircsprintf(got, "%u", 4294967295u);
        snprintf(want, sizeof(want), "%u", 4294967295u);
        if (strcmp(got, want)) { fail++; printf("  FAIL %%u  libc=%s got=%s\n", want, got); }
    }

    {   /* a real s2s NICK line shape: TS in the middle of a format */
        char got[512], want[512];
        total++;
        ircsprintf(got, "NICK %s %d %ld %s %s %s :%s",
                   "someone", 1, 2147483648L, "user", "host", "server", "real name");
        snprintf(want, sizeof(want), "NICK %s %d %ld %s %s %s :%s",
                 "someone", 1, 2147483648L, "user", "host", "server", "real name");
        if (strcmp(got, want)) {
            fail++;
            printf("  FAIL s2s NICK\n    libc=%s\n     got=%s\n", want, got);
        }
    }

    printf("%s: %d/%d checks passed\n", fail ? "RED" : "GREEN", total - fail, total);
    return fail != 0;
}
```
</details>
