### PR TITLE
ircd: rotate the activity log on the clock, not on traffic

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1149,9 +1149,14 @@
 #define ACTIVITY_LOG_FILE "./log/activity.log"
 
 /* ACTIVITY_LOG_ROTATE
- * Number of minutes to wait before rotating log file.
+ * Rotation interval, in minutes.
  * Timestamp will be appended to the name of the activity log file.
  * Example values are: 1440 (1 day) 10080 (1 week) 43200 (1 month)
+ *
+ * Boundaries are anchored on local midnight and stepped by this
+ * interval, so 1440 rotates exactly at 00:00 local time, 60 rotates
+ * on the hour, and so on. Rotation is driven by the main loop, so it
+ * happens on schedule even on a server with no activity to log.
  *
  * #define ACTIVITY_LOG_ROTATE 1440
  */

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -112,6 +112,9 @@ int		activity_fd;
 int		activity_open();
 void		activity_close();
 void		activity_log(char *, ...);
+#ifdef ACTIVITY_LOG_ROTATE
+void		activity_rotate_check(time_t);
+#endif
 #endif
 
 void        	server_reboot();
@@ -1365,7 +1368,11 @@ void io_loop()
 	
 	if ((timeofday >= nextping))
 	    nextping = check_pings(timeofday);
-	
+
+#if defined(USE_ACTIVITY_LOG) && defined(ACTIVITY_LOG_ROTATE)
+	activity_rotate_check(timeofday);
+#endif
+
 	if (dorehash && !lifesux) 
 	{
 	    (void) rehash(&me, &me, 1);
@@ -1650,6 +1657,50 @@ void build_version(void)
 
 
 #ifdef USE_ACTIVITY_LOG
+#ifdef ACTIVITY_LOG_ROTATE
+static time_t activity_nextrotate = 0;
+
+/* Compute the next rotation boundary.
+ * The boundary is anchored on local midnight and stepped by
+ * ACTIVITY_LOG_ROTATE minutes, so an interval of 1440 cuts exactly at
+ * 00:00 local time. The previous code used now + interval, which drifted
+ * away from the wall clock by however long the ircd took to notice the
+ * expiry. Recomputed from localtime() at every rotation, so a DST change
+ * re-anchors the boundary instead of carrying the offset forever.
+ */
+static time_t activity_next_rotate(time_t now)
+{
+    struct tm *t;
+    time_t boundary;
+    time_t step = 60 * (time_t) ACTIVITY_LOG_ROTATE;
+
+    if (step <= 0)		/* misconfigured: never rotate */
+	return now + (time_t) 0x7fffffff;
+
+    t = localtime(&now);
+    boundary = now - (t->tm_hour * 3600 + t->tm_min * 60 + t->tm_sec);
+
+    while (boundary <= now)
+	boundary += step;
+
+    return boundary;
+}
+
+/* Rotate the activity log if the boundary has passed.
+ * Called from io_loop() so rotation follows the clock rather than the
+ * traffic: the check used to live inside activity_log(), so a quiet
+ * server kept writing to the same file until something happened.
+ */
+void activity_rotate_check(time_t now)
+{
+    if (activity_fd < 0 || activity_nextrotate == 0 || now < activity_nextrotate)
+	return;
+
+    activity_close();
+    activity_open();
+}
+#endif
+
 /* Open activity file. Return 0 on success, 1 on error. */
 int activity_open()
 {
@@ -1660,7 +1711,7 @@ int activity_open()
 
     timenow = time(NULL);
     t=localtime(&timenow);
-    sprintf(filename,"%s.%04d%02d%02d-%02d%02d", ACTIVITY_LOG_FILE, 
+    sprintf(filename,"%s.%04d%02d%02d-%02d%02d", ACTIVITY_LOG_FILE,
 		     t->tm_year+1900, t->tm_mon+1, t->tm_mday, t->tm_hour, t->tm_min);
     if ((activity_fd = open(filename,
 #else
@@ -1668,8 +1719,13 @@ int activity_open()
 #endif
                             (O_CREAT|O_APPEND|O_NONBLOCK|O_RDWR),
 		            (S_IRUSR|S_IWUSR))) >= 0)
+    {
+#ifdef ACTIVITY_LOG_ROTATE
+	activity_nextrotate = activity_next_rotate(timenow);
+#endif
 	activity_log("(STARTING ACTIVITY LOG)");
-    
+    }
+
     return (activity_fd >= 0) ? 0 : 1;
 }
 
@@ -1690,26 +1746,14 @@ void activity_log(char *pattern, ...)
     va_list vl;
     int len;
     char *s;
-#ifdef ACTIVITY_LOG_ROTATE
-    static time_t nextrotate = 0;
 
-    if (nextrotate == 0)
-        nextrotate = 60 * ACTIVITY_LOG_ROTATE + time(NULL);
+    /* NOTE: rotation is no longer decided here. It used to be, which made
+     * it depend on there being something to log; it now lives in
+     * activity_rotate_check(), called from io_loop(). Keeping it out of
+     * this function also removes the close/open -> activity_log()
+     * recursion the old code had to reason about.
+     */
 
-    if (time(NULL)>nextrotate)
-    {
-	nextrotate = 60 * ACTIVITY_LOG_ROTATE + time(NULL);
-	
-	/* NOTE: these two functions call this one!
-	 * Anyway recursive calls are safe because we have
-	 * incremented nextrotate.
-	 */
-	activity_close();
-	activity_open();
-    }
-
-#endif
-       
     if (activity_fd>=0)
     {
 	struct iovec iov[3];


### PR DESCRIPTION
Requested on #it-opers: the activity log must close the old file and open a new one at midnight, independently of activity, so retention can be governed for GDPR purposes.

## What was wrong

Two separate problems, both in `src/ircd.c`:

1. **The check only ran when there was traffic.** `nextrotate` was tested inside `activity_log()`, so a server with nothing to log kept writing to the same file long past the configured interval. The rotation followed the traffic, not the clock.

2. **The boundary drifted.** On rotation the next one was set to `time(NULL) + 60 * ACTIVITY_LOG_ROTATE` — computed from the moment the expiry was *noticed*, not from the boundary itself. Every cut pushed the next one further from the wall clock, so `1440` never meant "at midnight" and after a few rotations it did not even mean a consistent time of day.

## What this does

- `activity_next_rotate()` anchors the boundary on **local midnight** and steps it by `ACTIVITY_LOG_ROTATE` minutes. `1440` cuts exactly at `00:00` local time, `60` on the hour, `43200` at midnight every 30 days. The anchor is recomputed from `localtime()` at every rotation, so a DST change re-anchors instead of carrying the offset forever.
- `activity_rotate_check()` is called from `io_loop()`, right after `check_pings()`. Rotation now happens on schedule on a completely silent server. Worst-case lateness is one main-loop wakeup (a few seconds), not "until someone talks".
- The check is gone from `activity_log()`, which also removes the `activity_close()`/`activity_open()` → `activity_log()` recursion the old code had a comment apologising for.
- A zero or negative interval means "never rotate" instead of spinning in the boundary loop.

No behaviour change when `ACTIVITY_LOG_ROTATE` is undefined.

## Testing

- `./configure && make` clean, no new warnings on `ircd.c`.
- `activity_next_rotate()` extracted verbatim from the built source and exercised standalone under `TZ=Europe/Rome`:

  | interval | input (local) | next boundary | delta |
  |---|---|---|---|
  | 1440 | 2026-08-05 22:40 | 2026-08-06 00:00 | +4800s |
  | 1440 | 2026-08-06 23:59:59 | 2026-08-07 00:00 | +1s |
  | 1440 | 2026-08-06 00:00:00 | 2026-08-07 00:00 | +86400s (no double rotation on the boundary) |
  | 60 | 2026-08-05 22:40 | 2026-08-05 23:00 | +1200s |
  | 43200 | 2026-08-05 22:40 | 2026-09-04 00:00 | 30 days, at midnight |
  | 1440 | 2026-10-31 01:00 (post-DST) | 2026-11-01 00:00 | +82800s = 23h, i.e. re-anchored, not 24h |

- Not deployed anywhere. Needs a run on a live server to confirm the rotation fires with no traffic.

## Not in this PR

Compressing and expiring the rotated files. That belongs outside the daemon: the ircd is a single-threaded event loop, and compressing a large log inline would stall every client for the duration. A cron job that gzips files older than a day and deletes them past the retention window keeps the policy in one place and costs the server nothing.