### PR TITLE
Ignore SIGUSR2 when built without USE_SSL

### DIFF
--- a/src/ircd.c
+++ b/src/ircd.c
@@ -1551,6 +1551,11 @@ static void setup_signals()
 	(void) sigemptyset(&act.sa_mask);
 	(void) sigaddset(&act.sa_mask, SIGUSR2);
 	(void) sigaction(SIGUSR2, &act, NULL);
+#else
+	act.sa_handler = SIG_IGN;
+	(void) sigemptyset(&act.sa_mask);
+	(void) sigaddset(&act.sa_mask, SIGUSR2);
+	(void) sigaction(SIGUSR2, &act, NULL);
 #endif /* USE_SSL */
 
 #else
@@ -1569,6 +1574,8 @@ static void setup_signals()
     (void) signal(SIGHUP, s_rehash);
 #ifdef USE_SSL
 	(void) signal(SIGUSR2, s_rehash_throttle_and_ssl);
+#else
+	(void) signal(SIGUSR2, SIG_IGN);
 #endif /* USE_SSL */
     (void) signal(SIGTERM, s_die);
     (void) signal(SIGINT, s_restart);


### PR DESCRIPTION
## Summary
- `setup_signals()` only registers a SIGUSR2 handler inside `#ifdef USE_SSL` (both the POSIX `sigaction` path and the legacy `signal()` fallback).
- When built without SSL support, SIGUSR2 is left at its default disposition, which **terminates the process**.
- A stray or accidental `SIGUSR2` on a non-SSL build kills the ircd instead of being a no-op.

## Fix
Explicitly set SIGUSR2 to `SIG_IGN` in the `#else` branch of both registration paths (`sigaction`-based and `signal()`-based), so behavior without `USE_SSL` is "ignore", matching what a user would reasonably expect from a signal that's only meaningful for SSL rehash/throttle.

## Test plan
- [ ] Build without `USE_SSL` and confirm `kill -USR2 <pid>` no longer terminates the daemon
- [ ] Build with `USE_SSL` and confirm SIGUSR2 still triggers SSL/throttle rehash as before