### PR TITLE
fix(trace): pass the missing tenth argument to RPL_TRACESERVER

### DIFF
--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -5228,7 +5228,8 @@ int m_trace(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		       link_u[i], name, 
 		       *(acptr->serv->bynick) ? acptr->serv->bynick : "*", 
 		       *(acptr->serv->byuser) ? acptr->serv->byuser : "*", 
-		       *(acptr->serv->byhost) ? acptr->serv->byhost : me.name);
+		       *(acptr->serv->byhost) ? acptr->serv->byhost : me.name,
+		       timeofday - acptr->lasttime);
 	    cnt++;
 	    break;
 	case STAT_LOG:


### PR DESCRIPTION
### The bug

`RPL_TRACESERVER` is declared in `src/s_err.c:234` as

```
":%s 206 %s Server %d %dS %dC %s %s!%s@%s %ld"
```

Ten conversions. The `STAT_SERVER` branch of `m_trace()` (`src/s_serv.c:5226`) passed only nine arguments, so the trailing `%ld` read a vararg slot that was never supplied.

### How it shows up

On a running server, numeric 206 prints garbage where the link idle time belongs:

```
206 vjtcldbg Server 60 3S 8C hub.testnet.azzurra.chat[unknown@0::0] AutoConn.!*@leaf6.testnet.azzurra.chat 99077947308556
```

That number is not a timestamp — it is whatever happened to sit in the next argument slot. Reproduced on the testnet with `/trace` from an oper connection.

### The fix

Pass `timeofday - acptr->lasttime` as the tenth argument. This matches the sibling `RPL_TRACESERVER` call a few lines below (`src/s_serv.c:5261`), which already supplies it, so the two call sites now agree on the numeric's shape.

### Testing

`src/s_serv.c` compiles clean with the change. A full link fails in this checkout for unrelated, pre-existing reasons (`check_for_spam`, `as_free_buf` undefined under the default configure options), so the resulting binary was not run.

### Note

While reading the same function, two further issues are visible but deliberately left out of this patch, since they need a decision rather than a one-liner: `link_s`/`link_u` are indexed by file descriptor without a bounds check, and the sibling call at `:5261` dereferences `acptr` after the loop, where it can be NULL or stale. Happy to open a separate issue for those.