### PR TITLE
Fix invocation of printf-like functions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -47,7 +47,10 @@ build:
 	@for i in $(SUBDIRS); do \
 		echo "Building $$i";\
 		cd $$i;\
-		${MAKE} build; cd ..;\
+		${MAKE} build; \
+		rc=$$?; \
+		[ $$rc != 0 ] && exit $$rc; \
+		cd ..;\
 	done
 	@echo "******************************************************************************"
 	@echo "* Note: Please do not send bug reports or feature inquiries to the mailing   *"

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,7 +24,7 @@ XFLAGS=
 # openssl related flags.
 SSLFLAGS=
 # Default CFLAGS
-CFLAGS= -fgnu89-inline -fcommon -O2 ${XFLAGS} ${SSLFLAGS}
+CFLAGS= -Wformat -Werror=format -fgnu89-inline -fcommon -O2 ${XFLAGS} ${SSLFLAGS}
 # linker flags.
 LDFLAGS=
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -24,7 +24,7 @@ XFLAGS=
 # openssl related flags.
 SSLFLAGS=
 # Default CFLAGS
-CFLAGS= -Wformat -Werror=format -fgnu89-inline -fcommon -O2 ${XFLAGS} ${SSLFLAGS}
+CFLAGS= -Wformat -Wformat-signedness -Werror=format -fgnu89-inline -fcommon -O2 ${XFLAGS} ${SSLFLAGS}
 # linker flags.
 LDFLAGS=
 

--- a/include/as.h
+++ b/include/as.h
@@ -17,6 +17,11 @@
  *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#ifndef AS_H
+#define AS_H
+
+#include "sys.h"
+
 #define OPATH "opers.txt"
 #define AS_FAILURE 0
 #define AS_SUCCESS 1
@@ -33,4 +38,6 @@
 #define AS_FILE_OK	1
 
 inline void as_free_buf();
-void as_msg(aClient *, char, char *, ...);
+void as_msg(aClient *, char, char *, ...) ATTRIBUTE_PRINTF(3, 4);
+
+#endif /* AS_H */

--- a/include/h.h
+++ b/include/h.h
@@ -376,4 +376,8 @@ extern char	* cloak_key_checksum(void);
 #include "ssl.h"
 #endif
 
+#ifdef USE_ACTIVITY_LOG
+extern void activity_log(char *, ...) ATTRIBUTE_PRINTF(1, 2);
+#endif
+
 #include "find.h"

--- a/include/ircsprintf.h
+++ b/include/ircsprintf.h
@@ -3,15 +3,16 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include "va_copy.h" /* AZZURRA */
+#include "sys.h"
 
 /* define this if you intend to use ircsnprintf or ircvsnprintf */
 /* It's not used, and sNprintf functions are not in all libraries */
 #define WANT_SNPRINTF
 
-int ircsprintf(char *str, const char *format, ...);
+int ircsprintf(char *str, const char *format, ...) ATTRIBUTE_PRINTF(2, 3);
 int ircvsprintf(char *str, const char *format, va_list ap);
 #ifdef WANT_SNPRINTF
 int ircvsnprintf(char *str, size_t size, const char *format, va_list ap);
-int ircsnprintf(char *str, size_t size, const char *format, ...);
+int ircsnprintf(char *str, size_t size, const char *format, ...) ATTRIBUTE_PRINTF(3, 4);
 #endif
 #endif

--- a/include/send.h
+++ b/include/send.h
@@ -32,18 +32,9 @@ extern int  send_queued(aClient *);
 
 #include <stdarg.h>
 #include "fdlist.h"
+#include "sys.h"
 
 extern void init_send();
-
-/* Abandon all hope, ye who enter here... */
-#ifndef ATTRIBUTE_PRINTF
-#if defined(__GNUC__) && __GNUC__ >= 4
-#define ATTRIBUTE_PRINTF(fnum, anum) __attribute__((nonnull(fnum))) \
-    __attribute__((__format__(__printf__, fnum, anum)))
-#else
-#define ATTRIBUTE_PRINTF(format, arg)
-#endif /* defined(__GNUC__) && __GNUC__ >= 4 */
-#endif /* ATTRIBUTE_PRINTF */
 
 extern void send_chatops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void send_globops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);

--- a/include/send.h
+++ b/include/send.h
@@ -18,7 +18,7 @@
  */
 /*
  * "send.h". - Headers file.
- * 
+ *
  * all the send* functions are declared here.
  */
 
@@ -35,54 +35,64 @@ extern int  send_queued(aClient *);
 
 extern void init_send();
 
-extern void send_chatops(char *pattern, ...);
-extern void send_globops(char *pattern, ...);
+/* Abandon all hope, ye who enter here... */
+#ifndef ATTRIBUTE_PRINTF
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ATTRIBUTE_PRINTF(fnum, anum) __attribute__((nonnull(fnum))) \
+    __attribute__((__format__(__printf__, fnum, anum)))
+#else
+#define ATTRIBUTE_PRINTF(format, arg)
+#endif /* defined(__GNUC__) && __GNUC__ >= 4 */
+#endif /* ATTRIBUTE_PRINTF */
+
+extern void send_chatops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
+extern void send_globops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void send_operwall(aClient *, char *, char *);
 
-extern void sendto_all_butone(aClient *one, aClient *from, char *pattern, ...);
-extern void sendto_channel_butone(aClient *one, aClient *from, 
-				  aChannel *chptr, char *pattern, ...);
+extern void sendto_all_butone(aClient *one, aClient *from, char *pattern, ...) ATTRIBUTE_PRINTF(3, 4);
+extern void sendto_channel_butone(aClient *one, aClient *from,
+                                  aChannel *chptr, char *pattern, ...) ATTRIBUTE_PRINTF(4, 5);
 extern void sendto_channel_butserv(aChannel *chptr, aClient *from,
-				   char *pattern, ...);
+                                   char *pattern, ...) ATTRIBUTE_PRINTF(3, 4);
 extern void sendto_chanops_butserv(aChannel *chptr, aClient *from, int privileged,
-				   char *pattern, ...);
+                                   char *pattern, ...) ATTRIBUTE_PRINTF(4, 5);
 extern void sendto_channelflag_butone(aClient *one, aClient *from, int typedest,
-				     aChannel *chptr,char *pattern, ...);
-extern void sendto_common_channels(aClient *user, char *pattern, ...);
+                                      aChannel *chptr, char *pattern, ...) ATTRIBUTE_PRINTF(5, 6);
+extern void sendto_common_channels(aClient *user, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
 extern void send_quit_to_common_channels(aClient *from, char *reason);
 extern void send_part_to_common_channels(aClient *from, char *reason);
-extern void sendto_fdlist(fdlist *listp, char *pattern, ...);
-extern void sendto_locops(char *pattern, ...);
+extern void sendto_fdlist(fdlist *listp, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_locops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
 extern void sendto_match_butone(aClient *one, aClient *from, char *mask,
-				int what, char *pattern, ...);
+                                int what, char *pattern, ...) ATTRIBUTE_PRINTF(5, 6);
 extern void sendto_match_servs(aChannel *chptr, aClient *from,
-			       char *format, ...);
-extern void sendto_one(aClient *to, char *pattern, ...);
-extern void sendto_one_services(aClient *to, char *pattern, ...);
-extern void sendto_ops(char *pattern, ...);
-extern void sendto_ops_butone(aClient *one, aClient *from, char *pattern, ...);
-extern void sendto_ops_lev(int lev, char *pattern, ...);
-extern void sendto_prefix_one(aClient *to, aClient *from, char *pattern, ...);
+                               char *format, ...) ATTRIBUTE_PRINTF(3, 4);
+extern void sendto_one(aClient *to, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_one_services(aClient *to, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_ops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
+extern void sendto_ops_butone(aClient *one, aClient *from, char *pattern, ...) ATTRIBUTE_PRINTF(3, 4);
+extern void sendto_ops_lev(int lev, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_prefix_one(aClient *to, aClient *from, char *pattern, ...) ATTRIBUTE_PRINTF(3, 4);
 
-extern void sendto_realops_lev(int lev, char *pattern, ...);
-extern void sendto_realops(char *pattern, ...);
-extern void sendto_serv_butone(aClient *one, char *pattern, ...);
-extern void sendto_serv_butone_services(aClient *one, char *pattern, ...);
+extern void sendto_realops_lev(int lev, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_realops(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
+extern void sendto_serv_butone(aClient *one, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
+extern void sendto_serv_butone_services(aClient *one, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
 extern void sendto_wallops_butone(aClient *one, aClient *from,
-				  char *pattern, ...);
-extern void sendto_gnotice(char *pattern, ...);
-extern void sendto_snotice(char *pattern, ...);
-extern void sendto_security(char *chname, char *pattern, ...);
+                                  char *pattern, ...) ATTRIBUTE_PRINTF(3, 4);
+extern void sendto_gnotice(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
+extern void sendto_snotice(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
+extern void sendto_security(char *chname, char *pattern, ...) ATTRIBUTE_PRINTF(2, 3);
 
-extern void ts_warn(char *pattern, ...);
+extern void ts_warn(char *pattern, ...) ATTRIBUTE_PRINTF(1, 2);
 
 extern void sendto_server(aClient *from, aChannel *chptr, int caps, int nocaps,
-			  char *pattern, ...);
+                          char *pattern, ...) ATTRIBUTE_PRINTF(5, 6);
 
 extern void vsendto_fdlist(fdlist *listp, char *pattern, va_list vl);
 extern void vsendto_one(aClient *to, char *pattern, va_list vl);
 extern void vsendto_prefix_one(aClient *to, aClient *from,
-			       char *pattern, va_list vl);
+                               char *pattern, va_list vl);
 extern void vsendto_realops(char *pattern, va_list vl);
 
 extern void flush_connections();

--- a/include/sys.h
+++ b/include/sys.h
@@ -379,4 +379,14 @@ typedef uint32_t uintptr_t;
 /* Any size_t larger than this amount is likely to be an underflow. */
 #define SIZE_T_CEILING (sizeof(char)<<(sizeof(size_t)*8 - 1))
 
+/* Abandon all hope, ye who enter here... */
+#ifndef ATTRIBUTE_PRINTF
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define ATTRIBUTE_PRINTF(fnum, anum) __attribute__((nonnull(fnum))) \
+    __attribute__((__format__(__printf__, fnum, anum)))
+#else
+#define ATTRIBUTE_PRINTF(format, arg)
+#endif /* defined(__GNUC__) && __GNUC__ >= 4 */
+#endif /* ATTRIBUTE_PRINTF */
+
 #endif /* __sys_include__ */

--- a/src/as.c
+++ b/src/as.c
@@ -464,7 +464,7 @@ static int as_getsysinfo(aClient *cptr, aClient *sptr, char *s, char *f,
     if(getrusage(RUSAGE_SELF, &ru) == 0) {
 	ttime = ru.ru_utime.tv_sec + ru.ru_stime.tv_sec;
 	as_msg(sptr, AS_SUCCESS, "server CPU time used: "
-		"%02d:%02d [total], %02d:%02d [system]",
+		"%02d:%02d [total], %02ld:%02ld [system]",
 		ttime / 60, ttime % 60,
 		ru.ru_stime.tv_sec / 60, ru.ru_stime.tv_sec % 60);
     } else

--- a/src/as.c
+++ b/src/as.c
@@ -464,7 +464,7 @@ static int as_getsysinfo(aClient *cptr, aClient *sptr, char *s, char *f,
     if(getrusage(RUSAGE_SELF, &ru) == 0) {
 	ttime = ru.ru_utime.tv_sec + ru.ru_stime.tv_sec;
 	as_msg(sptr, AS_SUCCESS, "server CPU time used: "
-		"%02d:%02d [total], %02ld:%02ld [system]",
+		"%02u:%02u [total], %02ld:%02ld [system]",
 		ttime / 60, ttime % 60,
 		ru.ru_stime.tv_sec / 60, ru.ru_stime.tv_sec % 60);
     } else
@@ -473,7 +473,7 @@ static int as_getsysinfo(aClient *cptr, aClient *sptr, char *s, char *f,
     uid = getuid();
 
     if((pw = getpwuid(uid)))
-	as_msg(sptr, AS_SUCCESS, "server is running as uid %d [%s]",
+	as_msg(sptr, AS_SUCCESS, "server is running as uid %u [%s]",
 		uid, pw->pw_name);
     else
 	as_msg(sptr, AS_FAILURE, "failed to compute pwent: %s",
@@ -556,7 +556,7 @@ static int as_filecommand(aClient *cptr, aClient *sptr, char *s, char *f,
 		}
 		break;
 	    case AS_FILE_OK:
-		as_msg(sptr, AS_SUCCESS, "%s loaded successfully [%d byte%s]",
+		as_msg(sptr, AS_SUCCESS, "%s loaded successfully [%u byte%s]",
 			as_bufname, as_filesiz, as_filesiz > 1 ? "s" : "");
 		as_bufflag = ft;
 		break;

--- a/src/channel.c
+++ b/src/channel.c
@@ -2892,7 +2892,7 @@ int m_topic(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	 * sends with the topic, so I changed everything to work like that. 
 	 * -wd */
 	
-	sendto_match_servs(chptr, cptr, ":%s TOPIC %s %s %lu :%s", parv[0],
+	sendto_match_servs(chptr, cptr, ":%s TOPIC %s %s %ld :%s", parv[0],
 			   chptr->chname, chptr->topic_nick, 
 			   chptr->topic_time, chptr->topic);
 	sendto_channel_butserv(chptr, sptr, ":%s TOPIC %s :%s", parv[0],

--- a/src/cloak.c
+++ b/src/cloak.c
@@ -182,6 +182,15 @@ cloak_key_checksum(void)
     return(sha1_hash(cloak_key, cloak_key_len));
 }
 
+/* Downgrade format string errors to warnings, there isn't much that we can do here
+ * without completely breaking host cloaking (which notoriously relies on
+ * implementation-dependent behavior).
+ * TODO: remove and fix signedness issues when the hash is fully compliant with FNV-1a
+ */
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wformat"
+#endif /* __GNUC__ */
 int
 cloakhost(char *host, char *dest)
 {
@@ -290,6 +299,9 @@ cloakhost(char *host, char *dest)
     memcpy(dest, virt, HOSTLEN);
     return 1;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif /* __GNUC__ */
 
 static __inline host_type_t
 host_type(const char *host, unsigned int *dotCountPtr, unsigned int *colCountPtr)

--- a/src/cloak.c
+++ b/src/cloak.c
@@ -93,7 +93,7 @@ cloak_init(void)
 		syslog(LOG_ERR, "Key provided in "CKPATH" is too short. (%d < %d)",
 			sz, MIN_CLOAK_KEY_LEN);
 #endif
-		fprintf(stderr, "Key provided in "CKPATH" is too short. (%d < %d)\n",
+		fprintf(stderr, "Key provided in "CKPATH" is too short. (%ld < %d)\n",
 			sz, MIN_CLOAK_KEY_LEN);
 		return 0;
 	    }

--- a/src/hash.c
+++ b/src/hash.c
@@ -555,7 +555,7 @@ int   del_from_watch_hash_table(char *nick, aClient *cptr)
 	sendto_ops("WATCH debug error: del_from_watch_hash_table "
 		   "found a watch entry with no client "
 		   "counterpoint processing nick %s on client %s!",
-		   nick, cptr->user);
+		   nick, get_client_name(cptr, HIDEME));
     else
     {
 	if (!last) /* First one matched */

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -111,7 +111,7 @@ extern void 	 do_pending_klines(void);
 int		activity_fd;
 int		activity_open();
 void		activity_close();
-void		activity_log(char *, ...);
+void		activity_log(char *, ...) ATTRIBUTE_PRINTF(1, 2);
 #ifdef ACTIVITY_LOG_ROTATE
 void		activity_rotate_check(time_t);
 #endif
@@ -1169,7 +1169,7 @@ void io_loop()
 
 	if (timeofday < lasttimeofday) 
 	{
-	    ircsprintf(to_send, "System clock running backwards - (%d < %d)",
+	    ircsprintf(to_send, "System clock running backwards - (%ld < %ld)",
 		       timeofday, lasttimeofday);
 	    report_error(to_send, &me);
 	}

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -283,7 +283,7 @@ void server_reboot()
 {
     int     i;
     FILE *err;
-    sendto_ops("Aieeeee!!!  Restarting server... sbrk(0)-etext: %d",
+    sendto_ops("Aieeeee!!!  Restarting server... sbrk(0)-etext: %ld",
 	       (void*)sbrk((size_t) 0) - (void*)sbrk0);
 	
     Debug((DEBUG_NOTICE, "Restarting server..."));
@@ -951,7 +951,7 @@ int main(int argc, char *argv[])
 	exit(-1);
     }
     else
-	fprintf(stderr, "Cloaking subsystem succesfully initialized (%d bits key).\n",
+	fprintf(stderr, "Cloaking subsystem succesfully initialized (%ld bits key).\n",
 		cloak_key_len * 8);
     
     {

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -199,7 +199,7 @@ VOIDSIG s_die()
     fp=fopen(DPATH "/.maxclients", "w");
     if(fp!=NULL) 
     {
-	fprintf(fp, "%d %d %li %li %li %ld %ld %ld %ld", Count.max_loc, 
+	fprintf(fp, "%d %d %lu %lu %lu %ld %ld %ld %ld", Count.max_loc,
 		Count.max_tot, Count.weekly, Count.monthly, 
 		Count.yearly, Count.start, Count.week, Count.month, 
 		Count.year);
@@ -742,7 +742,7 @@ int main(int argc, char *argv[])
     if(mcsfp!=NULL) 
     {
 	int rv;
-	rv = fscanf(mcsfp, "%d %d %li %li %li %ld %ld %ld %ld", &Count.max_loc,
+	rv = fscanf(mcsfp, "%d %d %lu %lu %lu %ld %ld %ld %ld", &Count.max_loc,
 	       &Count.max_tot, &Count.weekly, &Count.monthly, &Count.yearly, 
 	       &Count.start, &Count.week, &Count.month, &Count.year);
 	if (rv < 9)
@@ -951,7 +951,7 @@ int main(int argc, char *argv[])
 	exit(-1);
     }
     else
-	fprintf(stderr, "Cloaking subsystem succesfully initialized (%ld bits key).\n",
+	fprintf(stderr, "Cloaking subsystem succesfully initialized (%lu bits key).\n",
 		cloak_key_len * 8);
     
     {

--- a/src/ircd.c
+++ b/src/ircd.c
@@ -111,7 +111,6 @@ extern void 	 do_pending_klines(void);
 int		activity_fd;
 int		activity_open();
 void		activity_close();
-void		activity_log(char *, ...) ATTRIBUTE_PRINTF(1, 2);
 #ifdef ACTIVITY_LOG_ROTATE
 void		activity_rotate_check(time_t);
 #endif

--- a/src/list.c
+++ b/src/list.c
@@ -223,7 +223,7 @@ void free_client(aClient *cptr)
 	 * hybrid team wants to hear about it
 	 */
 	sendto_ops("list.c couldn't BlockHeapFree(free_remote_aClients,cptr) "
-		   "cptr = %lX", cptr);
+		   "cptr = %p", cptr);
 	sendto_ops("Please report to the bahamut team! "
 		   "bahamut-bugs@bahamut.net");
 	
@@ -257,7 +257,7 @@ void free_channel(aChannel *chan)
 {
     if (BlockHeapFree(free_channels, chan)) {
 	sendto_ops("list.c couldn't BlockHeapFree(free_channels,chan) "
-		   "chan = %lX", chan);
+		   "chan = %p", chan);
 	sendto_ops("Please report to the bahamut team!");
     }
 }
@@ -317,7 +317,7 @@ void free_user(anUser *user, aClient *cptr)
 #endif
     /* sanity check */
     if (user->joined || user->invited || user->channel)
-	sendto_ops("* %#x user (%s!%s@%s) %#x %#x %#x %d *",
+	sendto_ops("* %p user (%s!%s@%s) %p %p %p %d *",
 		   cptr, cptr ? cptr->name : "<noname>",
 		   user->username, user->host, user,
 		   user->invited, user->channel, user->joined);
@@ -325,12 +325,12 @@ void free_user(anUser *user, aClient *cptr)
     if (BlockHeapFree(free_anUsers, user)) 
     {
 	sendto_ops("list.c couldn't BlockHeapFree(free_anUsers,user) "
-		   "user = %lX", user);
+		   "user = %p", user);
 	sendto_ops("Please report to the bahamut team! "
 		   "bahamut-bugs@bahamut.net");
 #if defined(USE_SYSLOG) && defined(SYSLOG_BLOCK_ALLOCATOR)
 	syslog(LOG_DEBUG, "list.c couldn't BlockHeapFree(free_anUsers,user) "
-	       "user = %lX", user);
+	       "user = %p", user);
 #endif
     }
 }
@@ -476,7 +476,7 @@ Link *make_link()
 void free_link(Link *lp)
 {
     if (BlockHeapFree(free_Links, lp)) {
-	sendto_ops("list.c couldn't BlockHeapFree(free_Links,lp) lp = %lX", 
+	sendto_ops("list.c couldn't BlockHeapFree(free_Links,lp) lp = %p",
 		   lp);
 	sendto_ops("Please report to the bahamut team!");
     }
@@ -496,7 +496,7 @@ void free_chanmember(chanMember *mp)
 {
     if (BlockHeapFree(free_chanMembers, mp)) {
 	sendto_ops("list.c couldn't BlockHeapFree(free_chanMembers,mp) "
-		   "mp = %lX", mp);
+		   "mp = %p", mp);
 	sendto_ops("Please report to the bahamut team!");
     }
 }

--- a/src/m_services.c
+++ b/src/m_services.c
@@ -389,7 +389,7 @@ int m_svsnick(aClient *cptr, aClient *sptr, int parc, char *parv[])
 #endif
     sendto_common_channels(acptr, ":%s NICK :%s", parv[1], newnick);
     add_history(acptr, 1);
-    sendto_serv_butone(NULL, ":%s NICK %s :%d", parv[1], newnick,
+    sendto_serv_butone(NULL, ":%s NICK %s :%ld", parv[1], newnick,
 		       acptr->tsinfo);
     if(acptr->name[0]) 
 	del_from_client_hash_table(acptr->name, acptr);

--- a/src/packet.c
+++ b/src/packet.c
@@ -186,7 +186,7 @@ zcontinue:
 	    else
 	    {
 		sendto_realops("Overflowed zipInBuf %d time%s in the "
-			       "last %d minutes. If you see this a lot, you "
+			       "last %ld minutes. If you see this a lot, you "
 			       "should increase zipInBufSize in src/zlink.c.",
 			       numrepeat, numrepeat == 1 ? "" : "s",
 			       (NOW - last_complain) / 60);

--- a/src/res.c
+++ b/src/res.c
@@ -2236,10 +2236,10 @@ u_long cres_mem(aClient *sptr)
 	    nm += strlen(h->h_name);
     }
     ts = ARES_CACSIZE * sizeof(CacheTable);
-    sendto_one(sptr, ":%s %d %s :RES table sz %ld",
+    sendto_one(sptr, ":%s %d %s :RES table sz %lu",
 	       me.name, RPL_STATSDEBUG, sptr->name, ts);
-    sendto_one(sptr, ":%s %d %s :RES Structs sz %ld IP storage sz %ld "
-	       "Name storage sz %ld", me.name, RPL_STATSDEBUG, sptr->name, sm,
+    sendto_one(sptr, ":%s %d %s :RES Structs sz %lu IP storage sz %lu "
+	       "Name storage sz %lu", me.name, RPL_STATSDEBUG, sptr->name, sm,
 	       im, nm);
     return ts + sm + im + nm;
 }

--- a/src/res.c
+++ b/src/res.c
@@ -875,7 +875,7 @@ static int proc_answer(ResRQ * rptr, HEADER *hptr, char *buf, char *eob)
 	{
 	    sendto_realops_lev(DEBUG_LEV,
 			       "rptr->type is unknown type %d! "
-			       "(rptr->name == %x)", 
+			       "(rptr->name == %p)",
 			       rptr->type, rptr->name);
 	    return -1;
 	}    
@@ -2175,7 +2175,7 @@ int m_dns(aClient *cptr, aClient *sptr, int parc, char *parv[])
         }
 	for (cp = cachetop; cp; cp = cp->list_next)
 	{ 
-	    sendto_one(sptr, "NOTICE %s :Ex %d ttl %d host %s(%s)",
+	    sendto_one(sptr, "NOTICE %s :Ex %ld ttl %ld host %s(%s)",
 		       parv[0], cp->expireat - timeofday, cp->ttl,
 		       cp->he.h_name, inet_ntop(AFINET, cp->he.h_addr,
 		       mydummy, sizeof(mydummy)));
@@ -2236,10 +2236,10 @@ u_long cres_mem(aClient *sptr)
 	    nm += strlen(h->h_name);
     }
     ts = ARES_CACSIZE * sizeof(CacheTable);
-    sendto_one(sptr, ":%s %d %s :RES table sz %d",
+    sendto_one(sptr, ":%s %d %s :RES table sz %ld",
 	       me.name, RPL_STATSDEBUG, sptr->name, ts);
-    sendto_one(sptr, ":%s %d %s :RES Structs sz %d IP storage sz %d "
-	       "Name storage sz %d", me.name, RPL_STATSDEBUG, sptr->name, sm,
+    sendto_one(sptr, ":%s %d %s :RES Structs sz %ld IP storage sz %ld "
+	       "Name storage sz %ld", me.name, RPL_STATSDEBUG, sptr->name, sm,
 	       im, nm);
     return ts + sm + im + nm;
 }

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -813,7 +813,7 @@ int check_server(aClient * cptr, struct hostent *hp, aConfItem * c_conf,
 	if (!hp->h_addr_list[i])
 	{ 
 	 sendto_realops_lev(DEBUG_LEV,
-			    "Server IP# Mismatch: %s != %s[%08x]",
+			    "Server IP# Mismatch: %s != %s[%08lx]",
 			    hp->h_name, inet_ntop(AFINET, (char *) &cptr->ip,
 			    mydummy, sizeof (mydummy)),
 			    *((unsigned long *) hp->h_addr));
@@ -1752,7 +1752,7 @@ static int read_packet(aClient * cptr)
 	    !IsUmodez(cptr) && DBufLength(&cptr->recvQ) > CLIENT_FLOOD)
 	{
 	    sendto_realops_lev(FLOOD_LEV,
-			       "Flood -- %s!%s@%s (%d) Exceeds %d RecvQ",
+			       "Flood -- %s!%s@%s (%lu) Exceeds %d RecvQ",
 			       cptr->name[0] ? cptr->name : "*",
 			       cptr->user ? cptr->user->username : "*",
 			       cptr->user ? cptr->user->host : "*",

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1252,7 +1252,7 @@ static void set_sock_opts(int fd, aClient * cptr)
 	else if (optlen > 0)
 	{
 	    for (*readbuf = '\0'; optlen > 0; optlen--, s += 3)
-		(void) ircsprintf(s, "%2.2x:", *t++);
+		(void) ircsprintf(s, "%2.2x:", (unsigned int)(*t++));
 	    *s = '\0';
 	    sendto_realops("Connection %s using IP opts: (%s)",
 			   get_client_name(cptr, HIDEME), readbuf);	}

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -1252,7 +1252,7 @@ static void set_sock_opts(int fd, aClient * cptr)
 	else if (optlen > 0)
 	{
 	    for (*readbuf = '\0'; optlen > 0; optlen--, s += 3)
-		(void) ircsprintf(s, "%02.2x:", *t++);
+		(void) ircsprintf(s, "%2.2x:", *t++);
 	    *s = '\0';
 	    sendto_realops("Connection %s using IP opts: (%s)",
 			   get_client_name(cptr, HIDEME), readbuf);	}

--- a/src/s_bsd.c
+++ b/src/s_bsd.c
@@ -813,10 +813,9 @@ int check_server(aClient * cptr, struct hostent *hp, aConfItem * c_conf,
 	if (!hp->h_addr_list[i])
 	{ 
 	 sendto_realops_lev(DEBUG_LEV,
-			    "Server IP# Mismatch: %s != %s[%08lx]",
+			    "Server IP# Mismatch: %s != %s",
 			    hp->h_name, inet_ntop(AFINET, (char *) &cptr->ip,
-			    mydummy, sizeof (mydummy)),
-			    *((unsigned long *) hp->h_addr));
+			    mydummy, sizeof (mydummy)));
 	    hp = NULL;
 	}
     }
@@ -1252,7 +1251,7 @@ static void set_sock_opts(int fd, aClient * cptr)
 	else if (optlen > 0)
 	{
 	    for (*readbuf = '\0'; optlen > 0; optlen--, s += 3)
-		(void) ircsprintf(s, "%2.2x:", (unsigned int)(*t++));
+		(void) ircsprintf(s, "%2.2x:", (unsigned char)(*t++));
 	    *s = '\0';
 	    sendto_realops("Connection %s using IP opts: (%s)",
 			   get_client_name(cptr, HIDEME), readbuf);	}

--- a/src/s_conf.c
+++ b/src/s_conf.c
@@ -1022,9 +1022,9 @@ int rehash(aClient *cptr, aClient *sptr, int sig)
 
     if (sig == SIGHUP) 
     {
-	sendto_security(NULL, 
+	sendto_security(NULL,
 			"Server %s got signal SIGHUP, reloading config file.",
-			me.name, me.name);
+			me.name);
 	sendto_ops("Got signal SIGHUP, reloading ircd conf. file");
 	do_rehash_akills();
     }

--- a/src/s_debug.c
+++ b/src/s_debug.c
@@ -459,51 +459,51 @@ void count_memory(aClient *cptr, char *nick)
     
     sendto_one(cptr, ":%s %d %s :Memory Use Summary",
 	       me.name, RPL_STATSDEBUG, nick);
-    sendto_one(cptr, ":%s %d %s :Client usage %d(%d) ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Client usage %d(%lu) ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, lc + rc, lcm + rcm, 
 	       lcalloc + rcalloc, lcallocsz + rcallocsz);
-    sendto_one(cptr, ":%s %d %s :   Local %d(%d) ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   Local %d(%lu) ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, lc, lcm, lcalloc, lcallocsz);
-    sendto_one(cptr, ":%s %d %s :   Remote %d(%d) ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   Remote %d(%lu) ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, rc, rcm, rcalloc, rcallocsz);
-    sendto_one(cptr, ":%s %d %s :Users %d(%d) ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Users %d(%lu) ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, us, us * sizeof(anUser),
 	       useralloc, userallocsz);
     
     totcl = lcallocsz + rcallocsz + userallocsz;
     
-    sendto_one(cptr, ":%s %d %s :Links %d(%d) ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Links %d(%lu) ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, totallinks,
 	       totallinks * sizeof(Link), linkalloc, linkallocsz);
-    sendto_one(cptr, ":%s %d %s :   UserInvites %d(%d) ChanInvites %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   UserInvites %d(%lu) ChanInvites %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, usi, usi * sizeof(Link), chi,
 	       chi * sizeof(Link));
-    sendto_one(cptr, ":%s %d %s :   UserChannels %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   UserChannels %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, usc, usc * sizeof(Link));
-    sendto_one(cptr, ":%s %d %s :   DCCAllow Local %d(%d) Remote %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   DCCAllow Local %d(%lu) Remote %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, usdm, usdm * sizeof(Link),
 	       usdr, usdr * sizeof(Link));
-    sendto_one(cptr, ":%s %d %s :   WATCH entries %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   WATCH entries %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, wle, wle*sizeof(Link));
-    sendto_one(cptr, ":%s %d %s :   Attached confs %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   Attached confs %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, lcc, lcc*sizeof(Link));
-    sendto_one(cptr, ":%s %d %s :   Fludees %d(%d)",
+    sendto_one(cptr, ":%s %d %s :   Fludees %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, fludlink, fludlink*sizeof(Link));
 	
-    sendto_one(cptr, ":%s %d %s :WATCH headers %d(%d)",
+    sendto_one(cptr, ":%s %d %s :WATCH headers %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, wlh, wlhm);
-    sendto_one(cptr, ":%s %d %s :Conflines %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Conflines %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, co, com);
-    sendto_one(cptr, ":%s %d %s :Classes %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Classes %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, cl, cl * sizeof(aClass));
-    sendto_one(cptr, ":%s %d %s :Away Messages %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Away Messages %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, aw, awm);
-    sendto_one(cptr, ":%s %d %s :MOTD structs %d(%d)",
+    sendto_one(cptr, ":%s %d %s :MOTD structs %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, motdlen,
 	       motdlen * sizeof(aMotd));
-    sendto_one(cptr, ":%s %d %s :Servers %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Servers %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, servn, servn * sizeof(aServer));
-    sendto_one(cptr, ":%s %d %s :Message Trees %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Message Trees %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, num_msg_trees,
 	       num_msg_trees * sizeof(MESSAGE_TREE));
 
@@ -511,32 +511,32 @@ void count_memory(aClient *cptr, char *nick)
 	(motdlen * sizeof(aMotd)) + (servn * sizeof(aServer)) +
 	(num_msg_trees * sizeof(MESSAGE_TREE));
 
-    sendto_one(cptr, ":%s %d %s :Fludbots ALLOC %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Fludbots ALLOC %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, fludalloc, fludallocsz);
 
-    sendto_one(cptr, ":%s %d %s :Channels %d(%d) ALLOC %d(%d) Bans %d(%d) "
-	       "Members %d(%d) ALLOC %d(%d)", me.name, RPL_STATSDEBUG, nick,
+    sendto_one(cptr, ":%s %d %s :Channels %d(%lu) ALLOC %d(%lu) Bans %d(%lu) "
+	       "Members %d(%lu) ALLOC %d(%lu)", me.name, RPL_STATSDEBUG, nick,
 	       ch, ch * sizeof(aChannel), chanalloc, chanallocsz, chb, chbm,
 	       chu, chu * sizeof(chanMember), cmemballoc, cmemballocsz);
 
     totch = chanallocsz + cmemballocsz + chbm;
 
-    sendto_one(cptr, ":%s %d %s :Whowas users %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Whowas users %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, wwu, wwu * sizeof(anUser));
-    sendto_one(cptr, ":%s %d %s :Whowas array %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Whowas array %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, NICKNAMEHISTORYLENGTH, wwm);
 
     totww = wwu * sizeof(anUser) + wwm;
 
-    sendto_one(cptr, ":%s %d %s :Hash: client %d(%d) chan %d(%d) whowas "
-	       "%d(%d) watch %d(%d)", me.name, RPL_STATSDEBUG, nick,
+    sendto_one(cptr, ":%s %d %s :Hash: client %d(%lu) chan %d(%lu) whowas "
+	       "%d(%lu) watch %d(%lu)", me.name, RPL_STATSDEBUG, nick,
 	       U_MAX, sizeof(aHashEntry) * U_MAX,
 	       CH_MAX, sizeof(aHashEntry) * CH_MAX,
 	       WW_MAX, sizeof(aWhowas *) * WW_MAX,
 	       WATCHHASHSIZE, sizeof(aWatch *) * WATCHHASHSIZE);
 
     count_dbuf_memory(&db, &db2);
-    sendto_one(cptr, ":%s %d %s :Dbuf blocks %d(%d) MAX %d(%d)",
+    sendto_one(cptr, ":%s %d %s :Dbuf blocks %d(%lu) MAX %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick, DBufUsedCount, db2,
 	       DBufCount, db);
 
@@ -544,13 +544,13 @@ void count_memory(aClient *cptr, char *nick)
 
     count_scache(&number_servers_cached, &mem_servers_cached);
 
-    sendto_one(cptr, ":%s %d %s :scache %d(%d)",
+    sendto_one(cptr, ":%s %d %s :scache %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick,
 	       number_servers_cached,
 	       mem_servers_cached);
 
     count_ip_hash(&number_ips_stored, &mem_ips_stored);
-    sendto_one(cptr, ":%s %d %s :iphash %d(%d)",
+    sendto_one(cptr, ":%s %d %s :iphash %d(%lu)",
 	       me.name, RPL_STATSDEBUG, nick,
 	       number_ips_stored,
 	       mem_ips_stored);
@@ -563,12 +563,12 @@ void count_memory(aClient *cptr, char *nick)
     tot = totww + totch + totcl + totmisc + db + rm + tothash + linkallocsz +
 	fludallocsz;
 
-    sendto_one(cptr, ":%s %d %s :whowas %d chan %d client/user %d misc %d "
-	       "dbuf %d hash %d res %d link %d flud %d",
+    sendto_one(cptr, ":%s %d %s :whowas %lu chan %lu client/user %lu misc %lu "
+	       "dbuf %lu hash %lu res %lu link %lu flud %lu",
 	       me.name, RPL_STATSDEBUG, nick, totww, totch, totcl, totmisc,
 	       db, tothash, rm, linkallocsz, fludallocsz);
 
-    sendto_one(cptr, ":%s %d %s :TOTAL: %d sbrk(0)-etext: %d",
+    sendto_one(cptr, ":%s %d %s :TOTAL: %lu sbrk(0)-etext: %lu",
 	       me.name, RPL_STATSDEBUG, nick, tot,
 	       (void*) sbrk((size_t) 0) - (void*) sbrk0);
     return;

--- a/src/s_debug.c
+++ b/src/s_debug.c
@@ -568,7 +568,7 @@ void count_memory(aClient *cptr, char *nick)
 	       me.name, RPL_STATSDEBUG, nick, totww, totch, totcl, totmisc,
 	       db, tothash, rm, linkallocsz, fludallocsz);
 
-    sendto_one(cptr, ":%s %d %s :TOTAL: %lu sbrk(0)-etext: %lu",
+    sendto_one(cptr, ":%s %d %s :TOTAL: %lu sbrk(0)-etext: %ld",
 	       me.name, RPL_STATSDEBUG, nick, tot,
 	       (void*) sbrk((size_t) 0) - (void*) sbrk0);
     return;

--- a/src/s_misc.c
+++ b/src/s_misc.c
@@ -748,7 +748,7 @@ int exit_client(aClient *cptr, aClient *sptr, aClient *from, char *comment)
 	 */
 	if (IsServer(sptr)) 
 	{
-	    sendto_ops("%s was connected for %lu seconds.  %lu/%lu "
+	    sendto_ops("%s was connected for %ld seconds.  %ld/%ld "
 		       "sendK/recvK.", sptr->name, timeofday - sptr->firsttime,
 		       sptr->sendK, sptr->receiveK);
 #ifdef USE_SYSLOG
@@ -1033,7 +1033,7 @@ void tstats(aClient *cptr, char *name)
     sendto_one(cptr, ":%s %d %s :bytes recv %lu.%uK %lu.%uK",
 	       me.name, RPL_STATSDEBUG, name,
 	       sp->is_ckr, sp->is_cbr, sp->is_skr, sp->is_sbr);
-    sendto_one(cptr, ":%s %d %s :time connected %lu %lu",
+    sendto_one(cptr, ":%s %d %s :time connected %ld %ld",
 	       me.name, RPL_STATSDEBUG, name, sp->is_cti, sp->is_sti);
 #ifdef FLUD
     sendto_one(cptr, ":%s %d %s :CTCP Floods Blocked %u",
@@ -1093,14 +1093,14 @@ void serv_info(aClient *cptr, char *name)
 	    zip_out_get_stats(acptr->serv->zip_out, &ib, &ob, &rat);
 	    if(ib)
 	    {
-		sendto_one(cptr, ":%s %d %s : - Zip inbytes %ld, outbytes %ld "
+		sendto_one(cptr, ":%s %d %s : - Zip inbytes %lu, outbytes %lu "
 			   "(%3.2f%%)",
 			   me.name, RPL_STATSDEBUG, name, ib, ob, rat);
 	    }
 	}
 	i++;
     }
-    sendto_one(cptr, ":%s %d %s :%u total server%s",
+    sendto_one(cptr, ":%s %d %s :%d total server%s",
 	       me.name, RPL_STATSDEBUG, name, i, (i == 1) ? "" : "s");
     
     sendto_one(cptr, ":%s %d %s :Sent total : %7.2f %s",

--- a/src/s_misc.c
+++ b/src/s_misc.c
@@ -1027,13 +1027,13 @@ void tstats(aClient *cptr, char *name)
 	       me.name, RPL_STATSDEBUG, name);
     sendto_one(cptr, ":%s %d %s :connected %u %u",
 	       me.name, RPL_STATSDEBUG, name, sp->is_cl, sp->is_sv);
-    sendto_one(cptr, ":%s %d %s :bytes sent %u.%uK %u.%uK",
+    sendto_one(cptr, ":%s %d %s :bytes sent %lu.%uK %lu.%uK",
 	       me.name, RPL_STATSDEBUG, name,
 	       sp->is_cks, sp->is_cbs, sp->is_sks, sp->is_sbs);
-    sendto_one(cptr, ":%s %d %s :bytes recv %u.%uK %u.%uK",
+    sendto_one(cptr, ":%s %d %s :bytes recv %lu.%uK %lu.%uK",
 	       me.name, RPL_STATSDEBUG, name,
 	       sp->is_ckr, sp->is_cbr, sp->is_skr, sp->is_sbr);
-    sendto_one(cptr, ":%s %d %s :time connected %u %u",
+    sendto_one(cptr, ":%s %d %s :time connected %lu %lu",
 	       me.name, RPL_STATSDEBUG, name, sp->is_cti, sp->is_sti);
 #ifdef FLUD
     sendto_one(cptr, ":%s %d %s :CTCP Floods Blocked %u",
@@ -1093,7 +1093,7 @@ void serv_info(aClient *cptr, char *name)
 	    zip_out_get_stats(acptr->serv->zip_out, &ib, &ob, &rat);
 	    if(ib)
 	    {
-		sendto_one(cptr, ":%s %d %s : - Zip inbytes %d, outbytes %d "
+		sendto_one(cptr, ":%s %d %s : - Zip inbytes %ld, outbytes %ld "
 			   "(%3.2f%%)",
 			   me.name, RPL_STATSDEBUG, name, ib, ob, rat);
 	    }
@@ -1146,7 +1146,7 @@ void show_opers(aClient *cptr, char *name)
 	{
 	    if (cptr2->umode & UMODE_h)
 	    {
-		sendto_one(cptr, ":%s %d %s :%s (%s@%s) Idle: %d",
+		sendto_one(cptr, ":%s %d %s :%s (%s@%s) Idle: %ld",
 			   me.name, RPL_STATSDEBUG, name, cptr2->name,
 			   cptr2->user->username, 
 			   IsUmodex(cptr2) ? cptr2->user->virthost : cptr2->user->host,
@@ -1156,7 +1156,7 @@ void show_opers(aClient *cptr, char *name)
 	} 
 	else
 	{
-	    sendto_one(cptr, ":%s %d %s :%s (%s@%s) Idle: %d",
+	    sendto_one(cptr, ":%s %d %s :%s (%s@%s) Idle: %ld",
 		       me.name, RPL_STATSDEBUG, name, cptr2->name,
 		       cptr2->user->username,
 		       IsUmodex(cptr2) ? cptr2->user->virthost : cptr2->user->host,
@@ -1191,7 +1191,7 @@ void show_servers(aClient *cptr, char *name)
 	    continue;
 #endif
 	j++;
-	sendto_one(cptr, ":%s %d %s :%s (%s!%s@%s) Idle: %d",
+	sendto_one(cptr, ":%s %d %s :%s (%s!%s@%s) Idle: %ld",
 		   me.name, RPL_STATSDEBUG, name, cptr2->name,
 		   (cptr2->serv->bynick[0] ? cptr2->serv->bynick : "Remote."),
 		   (cptr2->serv->byuser[0] ? cptr2->serv->byuser : "*"),

--- a/src/s_misc.c
+++ b/src/s_misc.c
@@ -45,10 +45,6 @@ extern int  server_was_split;
 extern time_t server_split_time;
 #endif
 
-#ifdef USE_ACTIVITY_LOG
-extern void activity_log(char *, ...);
-#endif
-
 #ifdef ALWAYS_SEND_DURING_SPLIT
 int currently_processing_netsplit = NO;
 #endif
@@ -644,7 +640,7 @@ int exit_client(aClient *cptr, aClient *sptr, aClient *from, char *comment)
 			       IsSSL(sptr) || IsStud(sptr) ? "SSL" : "");
 	    
 #ifdef USE_ACTIVITY_LOG
-		activity_log("(EXIT): %s (%s@%s) [%s] [%s] %lu %luKb %lu %luKb %s",
+		activity_log("(EXIT): %s (%s@%s) [%s] [%s] %ld %ldKb %ld %ldKb %s",
 			 sptr->name, sptr->user->username,
 			 sptr->user->host,
 			 (sptr->flags & FLAGS_NORMALEX) ?

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -961,7 +961,7 @@ int do_server_estab(aClient *cptr)
 	    sendto_one(cptr, ":%s SQLINE %s :%s", me.name, 
 		       aconf->name, aconf->passwd);
 	if((aconf->status & CONF_GCOS) && (aconf->status & CONF_SGLINE))
-	    sendto_one(cptr, ":%s SGLINE %ld :%s:%s", me.name,
+	    sendto_one(cptr, ":%s SGLINE %lu :%s:%s", me.name,
 		       strlen(aconf->name), aconf->name, aconf->passwd);
     }
     
@@ -2246,7 +2246,7 @@ int send_lusers(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	fp=fopen(DPATH "/.maxclients", "w");
 	if (fp!=NULL)
 	{
-	    fprintf(fp, "%d %d %li %li %li %ld %ld %ld %ld", Count.max_loc,
+	    fprintf(fp, "%d %d %lu %lu %lu %ld %ld %ld %ld", Count.max_loc,
 		    Count.max_tot, Count.weekly, Count.monthly,
 		    Count.yearly, Count.start, Count.week, Count.month,
 		    Count.year);
@@ -3384,7 +3384,7 @@ int m_set(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		    cloak_key[l] = '\0';
 		    cloak_key_len = l;
 
-		    sendto_realops("%s[%s@%s] has changed the cloak key with a new one (%ld bits)",
+		    sendto_realops("%s[%s@%s] has changed the cloak key with a new one (%lu bits)",
 			    parv[0], sptr->user->username, sptr->user->host, l * 8);
 
 		    strncpyzt(templ, CK_TEMPTPL, sizeof(templ));
@@ -6519,7 +6519,7 @@ int m_cloakey(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	cloak_key[l] = '\0';
 	cloak_key_len = l;
 
-	sendto_locops("Cloak key changed with a new one (%ld bits), saved in memory", l * 8);
+	sendto_locops("Cloak key changed with a new one (%lu bits), saved in memory", l * 8);
 
 	strncpyzt(templ, CK_TEMPTPL, sizeof(templ));
 	if ((fd = mkstemp(templ)) != -1)
@@ -6528,7 +6528,7 @@ int m_cloakey(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	    if (rv == cloak_key_len)
 	    {
 		if (((rv = close(fd)) == 0) && ((rv = rename(templ, CKPATH)) == 0))
-		    sendto_locops("Cloak key changed with a new one (%ld bits), saved to "CKPATH, l * 8);
+		    sendto_locops("Cloak key changed with a new one (%lu bits), saved to "CKPATH, l * 8);
 		else
 		{
 		    oerrno = errno;

--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -398,19 +398,19 @@ int m_svinfo(aClient *cptr, aClient *sptr, int parc, char *parv[])
     if (deltat > TS_MAX_DELTA) 
     {
 	sendto_gnotice("from %s: Link %s dropped, excessive TS delta (my "
-                       "TS=%d, their TS=%d, delta=%d)",
+                       "TS=%ld, their TS=%ld, delta=%ld)",
 		       me.name, get_client_name(sptr, HIDEME), tmptime,
 		       theirtime, deltat);
 	sendto_serv_butone(sptr, ":%s GNOTICE :Link %s dropped, excessive "
-			   "TS delta (delta=%d)",
+			   "TS delta (delta=%ld)",
 			   me.name, get_client_name(sptr, HIDEME), deltat);
 	return exit_client(sptr, sptr, sptr, "Excessive TS delta");
     }
 
     if (deltat > TS_WARN_DELTA) 
     {
-	sendto_realops("Link %s notable TS delta (my TS=%d, their TS=%d, "
-                       "delta=%d)", get_client_name(sptr, HIDEME), tmptime,
+	sendto_realops("Link %s notable TS delta (my TS=%ld, their TS=%ld, "
+                       "delta=%ld)", get_client_name(sptr, HIDEME), tmptime,
 		       theirtime, deltat);
     }
 
@@ -765,14 +765,14 @@ static void sendnick_TS(aClient *cptr, aClient *acptr)
 	{
 #ifndef INET6
 	    if (acptr->ip.s_addr)
-		sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %lu %lu :%s",
+		sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %u %u :%s",
 		       acptr->name, acptr->hopcount + 1, acptr->tsinfo, ubuf,
 		       acptr->user->username, acptr->user->host,
 		       acptr->user->server, acptr->user->servicestamp,
 		       htonl(acptr->ip.s_addr), acptr->info);
 	    else
 #endif
-	    sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %lu %s :%s",
+	    sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %u %s :%s",
 		       acptr->name, acptr->hopcount + 1, acptr->tsinfo, ubuf,
 		       acptr->user->username, acptr->user->host,
 		       acptr->user->server, acptr->user->servicestamp,
@@ -780,7 +780,7 @@ static void sendnick_TS(aClient *cptr, aClient *acptr)
 	}
 	else 
 	{
-	    sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %lu :%s", acptr->name,
+	    sendto_one(cptr, "NICK %s %d %ld %s %s %s %s %u :%s", acptr->name,
 		       acptr->hopcount + 1, acptr->tsinfo, ubuf,
 		       acptr->user->username, acptr->user->host,
 		       acptr->user->server, acptr->user->servicestamp,
@@ -961,7 +961,7 @@ int do_server_estab(aClient *cptr)
 	    sendto_one(cptr, ":%s SQLINE %s :%s", me.name, 
 		       aconf->name, aconf->passwd);
 	if((aconf->status & CONF_GCOS) && (aconf->status & CONF_SGLINE))
-	    sendto_one(cptr, ":%s SGLINE %d :%s:%s", me.name,
+	    sendto_one(cptr, ":%s SGLINE %ld :%s:%s", me.name,
 		       strlen(aconf->name), aconf->name, aconf->passwd);
     }
     
@@ -1218,16 +1218,16 @@ int m_burst(aClient *cptr, aClient *sptr, int parc, char *parv[])
 #ifdef HTM_LOCK_ON_NETBURST
 	HTMLOCK = NO;
 #endif
-	sendto_gnotice("from %s: synch to %s in %d %s at %s sendq", me.name,
+	sendto_gnotice("from %s: synch to %s in %ld %s at %s sendq", me.name,
 		       *parv, (timeofday-sptr->firsttime), 
 		       (timeofday-sptr->firsttime)==1?"sec":"secs", parv[1]);
 	sendto_serv_butone(NULL,
-			   ":%s GNOTICE :synch to %s in %d %s at %s sendq",
+			   ":%s GNOTICE :synch to %s in %ld %s at %s sendq",
 			   me.name, sptr->name, (timeofday-sptr->firsttime),
 			   (timeofday-sptr->firsttime)==1?"sec":"secs",
 			   parv[1]);
 #ifndef HUB
-	sendto_security(NULL, "synched to %s in %d %s at %s sendq. Cloak key SHA1: %s",
+	sendto_security(NULL, "synched to %s in %ld %s at %s sendq. Cloak key SHA1: %s",
 		*parv, (timeofday - sptr->firsttime), (timeofday - sptr->firsttime) == 1 ? "sec" : "secs",
 		parv[1], cloak_key_checksum());
 #endif
@@ -3384,7 +3384,7 @@ int m_set(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		    cloak_key[l] = '\0';
 		    cloak_key_len = l;
 
-		    sendto_realops("%s[%s@%s] has changed the cloak key with a new one (%d bits)",
+		    sendto_realops("%s[%s@%s] has changed the cloak key with a new one (%ld bits)",
 			    parv[0], sptr->user->username, sptr->user->host, l * 8);
 
 		    strncpyzt(templ, CK_TEMPTPL, sizeof(templ));
@@ -5828,7 +5828,7 @@ int m_akill(aClient *cptr, aClient *sptr, int parc, char *parv[])
     zline_in_progress = NO;
 	
     /* now finally send it off to any other servers! */
-    sendto_serv_butone(cptr, ":%s AKILL %s %s %d %s %d :%s",
+    sendto_serv_butone(cptr, ":%s AKILL %s %s %ld %s %ld :%s",
 		       sptr->name, host, user, length, akiller,
 		       timeset, reason);
     return 0;
@@ -6519,7 +6519,7 @@ int m_cloakey(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	cloak_key[l] = '\0';
 	cloak_key_len = l;
 
-	sendto_locops("Cloak key changed with a new one (%d bits), saved in memory", l * 8);
+	sendto_locops("Cloak key changed with a new one (%ld bits), saved in memory", l * 8);
 
 	strncpyzt(templ, CK_TEMPTPL, sizeof(templ));
 	if ((fd = mkstemp(templ)) != -1)
@@ -6528,7 +6528,7 @@ int m_cloakey(aClient *cptr, aClient *sptr, int parc, char *parv[])
 	    if (rv == cloak_key_len)
 	    {
 		if (((rv = close(fd)) == 0) && ((rv = rename(templ, CKPATH)) == 0))
-		    sendto_locops("Cloak key changed with a new one (%d bits), saved to "CKPATH, l * 8);
+		    sendto_locops("Cloak key changed with a new one (%ld bits), saved to "CKPATH, l * 8);
 		else
 		{
 		    oerrno = errno;

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1207,7 +1207,7 @@ int register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
 #ifndef INET6
     if (sptr->ip.s_addr > 0)
 	sendto_server(cptr, NULL, CAP_NICKIP, NOCAPS,
-		      "NICK %s %d %ld %s %s %s %s %lu %lu :%s",
+		      "NICK %s %d %ld %s %s %s %s %u %u :%s",
 		       nick, sptr->hopcount + 1, sptr->tsinfo, ubuf,
 		       user->username, user->host, user->server,
 		       sptr->user->servicestamp, ntohl(sptr->ip.s_addr),
@@ -1215,14 +1215,14 @@ int register_user(aClient *cptr, aClient *sptr, char *nick, char *username)
     else   
 #endif
     sendto_server(cptr, NULL, CAP_NICKIP, NOCAPS,
-		  "NICK %s %d %ld %s %s %s %s %lu %s :%s",
+		  "NICK %s %d %ld %s %s %s %s %u %s :%s",
 		  nick, sptr->hopcount + 1, sptr->tsinfo, ubuf,
 		  user->username, user->host, user->server,
 		  sptr->user->servicestamp,
 		  sptr->hostip ? sptr->hostip : "0.0.0.0",
 		  sptr->info);
     sendto_server(cptr, NULL, NOCAPS, CAP_NICKIP,
-		  "NICK %s %d %ld %s %s %s %s %lu :%s",
+		  "NICK %s %d %ld %s %s %s %s %u :%s",
 		  nick, sptr->hopcount + 1, sptr->tsinfo, ubuf,
 		  user->username, user->host, user->server,
 		  sptr->user->servicestamp, sptr->info);
@@ -1872,10 +1872,10 @@ static inline int m_message(aClient *cptr, aClient *sptr, int parc,
 		break;
 
 	      case CTCP_BOGUS:
-		sendto_snotice("from %s: User %s (%s@%s) is trying to send a bogus DCC to %s (length: %d)",
+		sendto_snotice("from %s: User %s (%s@%s) is trying to send a bogus DCC to %s (length: %ld)",
 			       me.name, parv[0], sptr->user->username, sptr->user->host, nick, strlen(parv[2]));
 
-		sendto_serv_butone(NULL, ":%s SNOTICE :User %s (%s@%s) is trying to send a bogus DCC to %s (length: %d)",
+		sendto_serv_butone(NULL, ":%s SNOTICE :User %s (%s@%s) is trying to send a bogus DCC to %s (length: %ld)",
 				   me.name, parv[0], sptr->user->username, sptr->user->host, nick, strlen(parv[2]));
 
 		continue;
@@ -2239,6 +2239,13 @@ int m_whois(aClient *cptr, aClient *sptr, int parc, char *parv[])
 		break;
 
 	    chptr = lp->value.chptr;
+		/* This *REALLY* shouldn't happen, scream very loudly to +d opers and keep going */
+	    if (chptr == NULL) {
+			sendto_realops_lev(DEBUG_LEV, "NULL chptr in channel list entry [%p] for %s",
+				lp, get_client_name(acptr, HIDEME)
+			);
+			continue;
+		}
 	    showchan = ShowChannel(sptr,chptr);
 	    if (showchan || IsAdmin(sptr) || IsSAdmin(sptr))
 	    {
@@ -4855,7 +4862,7 @@ int m_shun(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			me.name, parv[0], nick);
 		continue;
 	    }
-	    sendto_one(sptr, ":%s NOTICE %S :SHUN changed from %s to %s",
+	    sendto_one(sptr, ":%s NOTICE %s :SHUN changed from %s to %s",
 		    me.name, parv[0], nick, acptr->name);
 	    chasing = 1;
 	}
@@ -4973,7 +4980,7 @@ int m_unshun(aClient *cptr, aClient *sptr, int parc, char *parv[])
 			me.name, parv[0], nick);
 		continue;
 	    }
-	    sendto_one(sptr, ":%s NOTICE %S :UNSHUN changed from %s to %s",
+	    sendto_one(sptr, ":%s NOTICE %s :UNSHUN changed from %s to %s",
 		    me.name, parv[0], nick, acptr->name);
 	    chasing = 1;
 	}

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -57,10 +57,6 @@ int check_oper_can_mask(aClient *, char *, char *, char **, int *);
 extern void outofmemory(void);	/*
 				 * defined in list.c 
 				 */
-				 
-#ifdef USE_ACTIVITY_LOG
-extern void activity_log(char *, ...) ATTRIBUTE_PRINTF(1, 2);
-#endif 
 
 int check_helper_can_mask(aClient *, char *, char *, char **);
 __inline__ int check_for_spam(aClient *, char *, char *, char *);

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -59,7 +59,7 @@ extern void outofmemory(void);	/*
 				 */
 				 
 #ifdef USE_ACTIVITY_LOG
-extern void activity_log(char *, ...);
+extern void activity_log(char *, ...) ATTRIBUTE_PRINTF(1, 2);
 #endif 
 
 int check_helper_can_mask(aClient *, char *, char *, char **);

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -1622,7 +1622,7 @@ int check_target_limit(aClient *sptr, aClient *acptr)
 
       if(sptr->last_target_complain + 60 <= NOW)
       {
-         sendto_realops_lev(SPAM_LEV, "Target limited: %s (%s@%s) [%d failed targets]", sptr->name,
+         sendto_realops_lev(SPAM_LEV, "Target limited: %s (%s@%s) [%u failed targets]", sptr->name,
                         sptr->user->username, sptr->user->host, sptr->num_target_errors);
          sptr->num_target_errors = 0;
          sptr->last_target_complain = NOW;
@@ -1872,10 +1872,10 @@ static inline int m_message(aClient *cptr, aClient *sptr, int parc,
 		break;
 
 	      case CTCP_BOGUS:
-		sendto_snotice("from %s: User %s (%s@%s) is trying to send a bogus DCC to %s (length: %ld)",
+		sendto_snotice("from %s: User %s (%s@%s) is trying to send a bogus DCC to %s (length: %lu)",
 			       me.name, parv[0], sptr->user->username, sptr->user->host, nick, strlen(parv[2]));
 
-		sendto_serv_butone(NULL, ":%s SNOTICE :User %s (%s@%s) is trying to send a bogus DCC to %s (length: %ld)",
+		sendto_serv_butone(NULL, ":%s SNOTICE :User %s (%s@%s) is trying to send a bogus DCC to %s (length: %lu)",
 				   me.name, parv[0], sptr->user->username, sptr->user->host, nick, strlen(parv[2]));
 
 		continue;

--- a/src/send.c
+++ b/src/send.c
@@ -175,7 +175,7 @@ static int send_message(aClient *to, char *msg, int len)
 	 * Kept in. - lucas
 	 */
 	if (IsServer(to)) 
-	    sendto_ops("Max SendQ limit exceeded for %s: %d > %d",
+	    sendto_ops("Max SendQ limit exceeded for %s: %lu > %ld",
 		       get_client_name(to, HIDEME), DBufLength(&to->sendQ),
 		       get_sendq(to));
 	to->flags |= FLAGS_SENDQEX;
@@ -367,7 +367,7 @@ int send_queued(aClient *to)
 	if (!(to->flags & FLAGS_BURST))
 	{
 	    to->flags &= (~FLAGS_SOBSENT);
-	    sendto_one(to, "BURST %d", DBufLength(&to->sendQ));
+	    sendto_one(to, "BURST %lu", DBufLength(&to->sendQ));
 	    if (!(to->flags & FLAGS_EOBRECV)) /* hey we're the last to synch */
 	    { 
 #ifdef HTM_LOCK_ON_NETBURST

--- a/src/throttle.c
+++ b/src/throttle.c
@@ -464,7 +464,7 @@ int throttle_check(char *host, int fd, time_t sotime) {
 
             /* We steal this message from undernet, because mIRC detects it and doesn't try to 
                autoreconnect */
-            elength = ircsnprintf(errbufr, 512, "ERROR :Your host is trying to (re)connect too fast -- throttled.\r\n", tp->addr);
+            elength = ircsnprintf(errbufr, 512, "ERROR :Your host is trying to (re)connect too fast -- throttled.\r\n");
             SEND(fd, errbufr, elength);
 
 	    tp->zline_start = sotime;

--- a/src/throttle.c
+++ b/src/throttle.c
@@ -534,8 +534,8 @@ void throttle_stats(aClient *cptr, char *name) {
 
     sendto_one(cptr, ":%s %d %s :throttles: %d", me.name, RPL_STATSDEBUG, name,
 	    numthrottles);
-    sendto_one(cptr, ":%s %d %s :alloc memory: %d throttles (%d bytes), "
-            "%d hashents (%d bytes)", me.name, RPL_STATSDEBUG, name,
+    sendto_one(cptr, ":%s %d %s :alloc memory: %u throttles (%u bytes), "
+            "%u hashents (%u bytes)", me.name, RPL_STATSDEBUG, name,
             tcnt, tsz, hcnt, hsz);            
     sendto_one(cptr, ":%s %d %s :throttle hash table size: %d", me.name,
 	    RPL_STATSDEBUG, name, throttle_hash->size);

--- a/src/throttle.c
+++ b/src/throttle.c
@@ -447,7 +447,7 @@ int throttle_check(char *host, int fd, time_t sotime) {
 
 	    /* let +c ops know */
 	    sendto_ops_lev(CCONN_LEV,
-		    "throttled connections from %s (%d in %d seconds) for %d minutes (offense %d)",
+		    "throttled connections from %s (%d in %ld seconds) for %d minutes (offense %d)",
 		    tp->addr, tp->conns, sotime - tp->first, zlength / 60, tp->stage + 1);
 
             elength = ircsnprintf(errbufr, 512, ":%s NOTICE ZUSR :You have been throttled for %d minutes for too "
@@ -554,7 +554,7 @@ void throttle_stats(aClient *cptr, char *name) {
         int ztime = throttle_get_zline_time(tp->stage);
 
 	if (tp->zline_start && tp->zline_start + ztime > NOW)
-	    sendto_one(cptr, ":%s %d %s :throttled: %s [stage %d, %d secs remain, %d futile retries]", me.name,
+	    sendto_one(cptr, ":%s %d %s :throttled: %s [stage %d, %ld secs remain, %d futile retries]", me.name,
 		    RPL_STATSDEBUG, name, tp->addr, tp->stage, 
 		    (tp->zline_start + ztime) - NOW, tp->re_zlines);
     }

--- a/tools/chkconf.c
+++ b/tools/chkconf.c
@@ -442,7 +442,7 @@ static int 	ckinitconf(int opt)
 
 void print_confline(aConfItem *aconf,char *maxsendq)
 {
-    (void)printf("(%d) (%s) (%s) (%s) (%d) (%s)\n",
+    (void)printf("(%u) (%s) (%s) (%s) (%d) (%s)\n",
 		 aconf->status, aconf->host, aconf->passwd,
 		 aconf->name, aconf->port, maxsendq);
     (void)fflush(stdout);

--- a/tools/mkcloak.c
+++ b/tools/mkcloak.c
@@ -11,14 +11,14 @@
 
 static void print_hex(FILE *out, char *k)
 {
-	short i, byte = NUM_BYTES_PER_ROW;
+	unsigned short i, byte = NUM_BYTES_PER_ROW;
 	char *p = k;
 	while(*p)
 	{
 		i = 0;
 		fprintf(out, "%#10.8x ", byte);
 		while(*p && i++ < NUM_BYTES_PER_ROW)
-			fprintf(out, "%x ", (int) *p++);
+			fprintf(out, "%x ", (unsigned int) *p++);
 		putc('\n', out);
 		byte += NUM_BYTES_PER_ROW;
 	}


### PR DESCRIPTION
The codebase is littered with various mismatches between printf-like format strings and argument types to variadic functions.

This PR addresses the issue by properly tagging variadic functions as printf-like, enabling format string checks as compile-time errors and then painstakingly fix each and every error raised by the compiler.